### PR TITLE
fix: 修复每日新闻 GoCN 域名错误链接

### DIFF
--- a/201704/20170424-20170430.md
+++ b/201704/20170424-20170430.md
@@ -20,7 +20,7 @@
 
 * 编辑: 谢烟客
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/article/306
+* GoCN 归档: https://gocn.vip/topics/8463
 
 ### GoCN每日新闻(2017-04-27)
 
@@ -43,8 +43,8 @@
 5. Go数据分析和数据工具集合 http://gopherdata.io/
 
 招聘信息：
-【北京】360导航事业部招聘Go工程师 https://gocn.io/article/308
-【上海】appcoachs招聘golang工程师 https://gocn.io/article/309
+【北京】360导航事业部招聘Go工程师 https://gocn.vip/topics/8465
+【上海】appcoachs招聘golang工程师 https://gocn.vip/topics/8466
 
 * 编辑: Asta & 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
@@ -59,7 +59,7 @@
 5. Go项目体检器 https://goreportcard.com/
 
 招聘信息：
-【上海】哔哩哔哩招聘Go开发工程师 https://gocn.io/article/310
+【上海】哔哩哔哩招聘Go开发工程师 https://gocn.vip/topics/8467
 【杭州】云霁科技寻觅优秀gopher https://gocn.vip/topics/691
 
 * 编辑: Asta
@@ -76,4 +76,4 @@
 
 * 编辑: 谢烟客
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/article/311
+* GoCN 归档: https://gocn.vip/topics/8468

--- a/201704/20170424-20170430.md
+++ b/201704/20170424-20170430.md
@@ -8,7 +8,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/729
+* GoCN 归档: https://gocn.vip/topics/729
 
 ### GoCN每日新闻(2017-04-26)
 
@@ -32,7 +32,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/731
+* GoCN 归档: https://gocn.vip/topics/731
 
 ### GoCN每日新闻(2017-04-28)
 
@@ -48,7 +48,7 @@
 
 * 编辑: Asta & 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/734
+* GoCN 归档: https://gocn.vip/topics/734
 
 ### GoCN每日新闻(2017-04-29)
 
@@ -60,11 +60,11 @@
 
 招聘信息：
 【上海】哔哩哔哩招聘Go开发工程师 https://gocn.io/article/310
-【杭州】云霁科技寻觅优秀gopher https://gocn.io/question/691
+【杭州】云霁科技寻觅优秀gopher https://gocn.vip/topics/691
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/737
+* GoCN 归档: https://gocn.vip/topics/737
 
 ### GoCN每日新闻(2017-04-30)
 

--- a/201705/20170501-20170507.md
+++ b/201705/20170501-20170507.md
@@ -4,13 +4,13 @@
 2. Go没有引用传值 https://dave.cheney.net/2017/04/29/there-is-no-pass-by-reference-in-go
 3. Golang 在mac上用VSCode开发、Delve调试 http://www.cnblogs.com/ficow/p/6785905.html
 4. GopherChina参会感悟 http://fuxiaohei.me/2017/4/22/gopherchina-2017.html
-5. 【上海】汇宜金融 招聘Gopher https://gocn.io/question/724
+5. 【上海】汇宜金融 招聘Gopher https://gocn.vip/topics/724
 
-【北京】10年老厂招聘GO高级工程师 https://gocn.io/question/694
+【北京】10年老厂招聘GO高级工程师 https://gocn.vip/topics/694
 
 * 编辑: Asta & 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/739
+* GoCN 归档: https://gocn.vip/topics/739
 
 ### GoCN每日新闻(2017-05-02)
 
@@ -22,7 +22,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/740
+* GoCN 归档: https://gocn.vip/topics/740
 
 ### GoCN每日新闻(2017-05-03)
 
@@ -34,19 +34,19 @@
 
 * 编辑: 谢烟客 & 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/744
+* GoCN 归档: https://gocn.vip/topics/744
 
 ### GoCN每日新闻(2017-05-04)
 
 1. 类型的安全还是便利 https://lanreadelowo.com/blog/2017/05/02/type-safety-or-convenience/
 2. Go的内存管理 http://www.tapirgames.com/blog/golang-memory-management
-3. 两年后端程序员的困惑 https://gocn.io/question/745
+3. 两年后端程序员的困惑 https://gocn.vip/topics/745
 4. 数据库访问层upperDB https://upper.io/db.v3
-5. Go和Java的interface有什么不同 https://gocn.io/question/73
+5. Go和Java的interface有什么不同 https://gocn.vip/topics/73
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/746
+* GoCN 归档: https://gocn.vip/topics/746
 
 ### GoCN每日新闻(2017-05-05)
 
@@ -58,7 +58,7 @@
 
 * 编辑: Asta & 谢烟客
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/748
+* GoCN 归档: https://gocn.vip/topics/748
 
 ### GoCN每日新闻(2017-05-06)
 
@@ -70,7 +70,7 @@
 
 * 编辑: Asta & 傅小黑 & 谢烟客
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/751
+* GoCN 归档: https://gocn.vip/topics/751
 
 ### GoCN每日新闻(2017-05-07)
 
@@ -82,4 +82,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/752
+* GoCN 归档: https://gocn.vip/topics/752

--- a/201705/20170508-20170514.md
+++ b/201705/20170508-20170514.md
@@ -8,7 +8,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/753
+* GoCN 归档: https://gocn.vip/topics/753
 
 ### GoCN每日新闻(2017-05-09)
 
@@ -20,7 +20,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/756
+* GoCN 归档: https://gocn.vip/topics/756
 
 ### GoCN每日新闻(2017-05-10)
 
@@ -40,7 +40,7 @@ Gopher北京meetup   时间：6-25
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/758
+* GoCN 归档: https://gocn.vip/topics/758
 
 ### GoCN每日新闻(2017-05-11)
 
@@ -63,7 +63,7 @@ OneAPM 《百万并发云压测平台的关键技术》
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/762
+* GoCN 归档: https://gocn.vip/topics/762
 
 ### GoCN每日新闻(2017-05-12)
 
@@ -74,7 +74,7 @@ OneAPM 《百万并发云压测平台的关键技术》
 5. Go中处理error的模式 https://mijailovic.net/2017/05/09/error-handling-patterns-in-go/
 
 招聘信息：
-【北京】滴滴 https://gocn.io/question/766
+【北京】滴滴 https://gocn.vip/topics/766
 活动预告：
 Gopher北京meetup   时间：6-25
 今日头条 分享头条的微服务
@@ -85,7 +85,7 @@ Gopher北京meetup   时间：6-25
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/767
+* GoCN 归档: https://gocn.vip/topics/767
 
 ### GoCN每日新闻(2017-05-13)
 
@@ -100,7 +100,7 @@ Gopher北京meetup   时间：6-25
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/771
+* GoCN 归档: https://gocn.vip/topics/771
 
 ### GoCN每日新闻(2017-05-14)
 
@@ -120,4 +120,4 @@ Gopher北京meetup   时间：6-25  最后20张入场券
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/772
+* GoCN 归档: https://gocn.vip/topics/772

--- a/201705/20170508-20170514.md
+++ b/201705/20170508-20170514.md
@@ -52,7 +52,7 @@ Gopher北京meetup   时间：6-25
 
 招聘信息
 【上海】饿了么 https://gocn.io/article/320
-【南京】孩子王 https://gocn.io/article/317
+【南京】孩子王 https://gocn.vip/topics/8473
 活动预告：
 新时代下的高效运维之道   时间：5-13
 七牛 《To B 企业运维的机遇和挑战》

--- a/201705/20170515-20170521.md
+++ b/201705/20170515-20170521.md
@@ -11,7 +11,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/773
+* GoCN 归档: https://gocn.vip/topics/773
 
 ### GoCN每日新闻(2017-05-16)
 
@@ -30,7 +30,7 @@
 
 * 编辑: 谢烟客
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/776
+* GoCN 归档: https://gocn.vip/topics/776
 
 ### GoCN每日新闻(2017-05-17)
 
@@ -49,7 +49,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/777
+* GoCN 归档: https://gocn.vip/topics/777
 
 ### GoCN每日新闻(2017-05-18)
 
@@ -70,7 +70,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/780
+* GoCN 归档: https://gocn.vip/topics/780
 
 ### GoCN每日新闻(2017-05-19)
 
@@ -81,11 +81,11 @@
 5. 一款 go 的 3D 游戏引擎 https://github.com/g3n/engine
 
 招聘信息：
-招聘go工程师，坐标济南，薪资8-10K https://gocn.io/question/631
+招聘go工程师，坐标济南，薪资8-10K https://gocn.vip/topics/631
 
 * 编辑: 谢烟客
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/784
+* GoCN 归档: https://gocn.vip/topics/784
 
 ### GoCN每日新闻(2017-05-20)
 
@@ -104,7 +104,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/787
+* GoCN 归档: https://gocn.vip/topics/787
 
 ### GoCN每日新闻(2017-05-21)
 
@@ -123,4 +123,4 @@
 
 * 编辑: Asta & 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/789
+* GoCN 归档: https://gocn.vip/topics/789

--- a/201705/20170522-20170528.md
+++ b/201705/20170522-20170528.md
@@ -15,7 +15,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/791
+* GoCN 归档: https://gocn.vip/topics/791
 
 ### GoCN每日新闻(2017-05-23)
 
@@ -30,7 +30,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/795
+* GoCN 归档: https://gocn.vip/topics/795
 
 ### GoCN每日新闻(2017-05-24)
 
@@ -49,7 +49,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/798
+* GoCN 归档: https://gocn.vip/topics/798
 
 ### GoCN每日新闻(2017-05-25)
 
@@ -68,7 +68,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/802
+* GoCN 归档: https://gocn.vip/topics/802
 
 ### GoCN每日新闻(2017-05-26)
 
@@ -87,7 +87,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/807
+* GoCN 归档: https://gocn.vip/topics/807
 
 ### GoCN每日新闻(2017-05-27)
 
@@ -99,7 +99,7 @@
 
 * 编辑: Asta & 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/808
+* GoCN 归档: https://gocn.vip/topics/808
 
 ### GoCN每日新闻(2017-05-28)
 
@@ -118,4 +118,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/811
+* GoCN 归档: https://gocn.vip/topics/811

--- a/201705/20170522-20170528.md
+++ b/201705/20170522-20170528.md
@@ -103,7 +103,7 @@
 
 ### GoCN每日新闻(2017-05-28)
 
-1. 项目内存泄露排查 + 使用Go pprof定位内存泄露 https://gocn.io/article/340
+1. 项目内存泄露排查 + 使用Go pprof定位内存泄露 https://gocn.vip/topics/8496
 2. Go HTTP 超时完全指南 https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
 3. gollvm From Google https://go.googlesource.com/gollvm/
 4. Golang hashmap的使用及实现 https://www.goinggo.net/2013/12/macro-view-of-map-internals-in-go.html

--- a/201705/20170529-20170604.md
+++ b/201705/20170529-20170604.md
@@ -8,7 +8,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/813
+* GoCN 归档: https://gocn.vip/topics/813
 
 ### GoCN每日新闻(2017-05-30)
 
@@ -20,7 +20,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/815
+* GoCN 归档: https://gocn.vip/topics/815
 
 ### GoCN每日新闻(2017-05-31)
 
@@ -39,7 +39,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/816
+* GoCN 归档: https://gocn.vip/topics/816
 
 ### GoCN每日新闻(2017-06-01)
 
@@ -55,7 +55,7 @@ https://book.douban.com/subject/26586598/
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/819
+* GoCN 归档: https://gocn.vip/topics/819
 
 ### GoCN每日新闻(2017-06-02)
 
@@ -72,7 +72,7 @@ https://book.douban.com/subject/26586598/
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/821
+* GoCN 归档: https://gocn.vip/topics/821
 
 ### GoCN每日新闻(2017-06-03)
 
@@ -89,7 +89,7 @@ https://book.douban.com/subject/26586598/
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/824
+* GoCN 归档: https://gocn.vip/topics/824
 
 ### GoCN每日新闻(2017-06-04)
 
@@ -106,4 +106,4 @@ https://book.douban.com/subject/26586598/
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/827
+* GoCN 归档: https://gocn.vip/topics/827

--- a/201706/20170605-20170611.md
+++ b/201706/20170605-20170611.md
@@ -76,7 +76,7 @@ HTTPS 性能优化学习 http://yangxikun.com/https/2017/05/13/https-optimize.ht
 2. 微软提供的Go写MSSQL的入门教程 https://www.microsoft.com/en-us/sql-server/developer-get-started/go/mac/
 3. 指针和引用 https://fullstack.network/session-17-pointers-in-go-difference-between-pass-by-pointer-and-pass-by-value-6ba83e4811d5
 4. 暴露metrics包详解 https://orangetux.nl/post/expvar_in_action/
-5. GOLANG空指针崩溃时堆栈消失和解决方案 https://gocn.io/article/351
+5. GOLANG空指针崩溃时堆栈消失和解决方案 https://gocn.vip/topics/8507
 
 招聘信息：
 【北京】滴滴 运维架构师&云平台产品经理 https://gocn.vip/topics/838
@@ -94,11 +94,11 @@ HTTPS 性能优化学习 http://yangxikun.com/https/2017/05/13/https-optimize.ht
 1. Dep初探 http://tonybai.com/2017/06/08/first-glimpse-of-dep/
 2. 持续交付武器Spinnaker https://mp.weixin.qq.com/s/0SER6Btz0g-6GF6wiUF8mQ
 3. Go 开发理念 http://peter.bourgon.org/blog/2017/06/09/theory-of-modern-go.html
-4. Golang如何使用mock做测试 https://gocn.io/article/353
+4. Golang如何使用mock做测试 https://gocn.vip/topics/8509
 5. gogland编辑器支持远程调试 https://blog.jetbrains.com/go/2017/06/09/gogland-eap-9-is-available/
 
 招聘信息：
-【上海】UCloud https://gocn.io/article/352
+【上海】UCloud https://gocn.vip/topics/8508
 【北京】滴滴  https://gocn.vip/topics/838
 【杭州】小卡 https://gocn.vip/topics/845
 

--- a/201706/20170605-20170611.md
+++ b/201706/20170605-20170611.md
@@ -14,7 +14,7 @@ Reddit代码部署演变史 https://redditblog.com/2017/06/02/the-evolution-of-c
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/828
+* GoCN 归档: https://gocn.vip/topics/828
 
 ### GoCN每日新闻(2017-06-06)
 
@@ -25,12 +25,12 @@ Reddit代码部署演变史 https://redditblog.com/2017/06/02/the-evolution-of-c
 5. Linux异步IO https://jvns.ca/blog/2017/06/03/async-io-on-linux--select--poll--and-epoll/
 
 招聘信息
-【上海】https://gocn.io/question/830
+【上海】https://gocn.vip/topics/830
 【珠海、北京】掌游天下 https://gocn.io/article/339
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/831
+* GoCN 归档: https://gocn.vip/topics/831
 
 ### GoCN每日新闻(2017-06-07)
 
@@ -49,7 +49,7 @@ HTTPS 性能优化学习 http://yangxikun.com/https/2017/05/13/https-optimize.ht
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/837
+* GoCN 归档: https://gocn.vip/topics/837
 
 ### GoCN每日新闻(2017-06-08)
 
@@ -60,7 +60,7 @@ HTTPS 性能优化学习 http://yangxikun.com/https/2017/05/13/https-optimize.ht
 5. 代码审查关注什么：SOLID 原则 http://www.jianshu.com/p/2cd98d697adc
 
 招聘信息：
-【北京】滴滴 运维架构师&云平台产品经理 https://gocn.io/question/838
+【北京】滴滴 运维架构师&云平台产品经理 https://gocn.vip/topics/838
 活动预告：
 上海Gopher meetup 报名地址：http://www.bagevent.com/event/569317
 深圳Gopher meetup 报名地址：http://www.bagevent.com/event/575820
@@ -68,7 +68,7 @@ HTTPS 性能优化学习 http://yangxikun.com/https/2017/05/13/https-optimize.ht
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/841
+* GoCN 归档: https://gocn.vip/topics/841
 
 ### GoCN每日新闻(2017-06-09)
 
@@ -79,7 +79,7 @@ HTTPS 性能优化学习 http://yangxikun.com/https/2017/05/13/https-optimize.ht
 5. GOLANG空指针崩溃时堆栈消失和解决方案 https://gocn.io/article/351
 
 招聘信息：
-【北京】滴滴 运维架构师&云平台产品经理 https://gocn.io/question/838
+【北京】滴滴 运维架构师&云平台产品经理 https://gocn.vip/topics/838
 活动预告：
 上海Gopher meetup 报名地址：http://www.bagevent.com/event/569317
 深圳Gopher meetup 报名地址：http://www.bagevent.com/event/575820
@@ -87,7 +87,7 @@ HTTPS 性能优化学习 http://yangxikun.com/https/2017/05/13/https-optimize.ht
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/842
+* GoCN 归档: https://gocn.vip/topics/842
 
 ### GoCN每日新闻(2017-06-10)
 
@@ -99,12 +99,12 @@ HTTPS 性能优化学习 http://yangxikun.com/https/2017/05/13/https-optimize.ht
 
 招聘信息：
 【上海】UCloud https://gocn.io/article/352
-【北京】滴滴  https://gocn.io/question/838
-【杭州】小卡 https://gocn.io/question/845
+【北京】滴滴  https://gocn.vip/topics/838
+【杭州】小卡 https://gocn.vip/topics/845
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/847
+* GoCN 归档: https://gocn.vip/topics/847
 
 ### GoCN每日新闻(2017-06-11)
 
@@ -115,7 +115,7 @@ HTTPS 性能优化学习 http://yangxikun.com/https/2017/05/13/https-optimize.ht
 5. redis集群实现原理探究 http://tech.youzan.com/redisji-qun-shi-xian-yuan-li-tan-tao/
 
 招聘信息：
-【北京】滴滴 运维架构师&云平台产品经理 https://gocn.io/question/838
+【北京】滴滴 运维架构师&云平台产品经理 https://gocn.vip/topics/838
 活动预告：
 上海Gopher meetup 报名地址：http://www.bagevent.com/event/569317
 深圳Gopher meetup 报名地址：http://www.bagevent.com/event/575820
@@ -123,4 +123,4 @@ HTTPS 性能优化学习 http://yangxikun.com/https/2017/05/13/https-optimize.ht
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/850
+* GoCN 归档: https://gocn.vip/topics/850

--- a/201706/20170612-20170618.md
+++ b/201706/20170612-20170618.md
@@ -3,7 +3,7 @@
 1. 一致性hash库 https://github.com/lafikl/consistent
 2. 如何设计包级别的变量 https://dave.cheney.net/2017/06/11/go-without-package-scoped-variables
 3. 深入理解Go的interface http://mp.weixin.qq.com/s/CnMWXU4CthoSWp4jtymjiQ
-4. Go逃逸分析 https://gocn.io/article/355
+4. Go逃逸分析 https://gocn.vip/topics/8511
 5. 理解Go的nil http://sanyuesha.com/2017/06/11/go-nil/
 
 * 编辑: 傅小黑 & Asta
@@ -19,7 +19,7 @@
 5. Go写的操作系统(实验阶段) https://github.com/achilleasa/gopher-os
 
 招聘：
-【北京】Grab https://gocn.io/article/357
+【北京】Grab https://gocn.vip/topics/8513
 活动预告：
 上海Gopher meetup 报名地址：http://www.bagevent.com/event/569317
 深圳Gopher meetup 报名地址：http://www.bagevent.com/event/575820
@@ -72,7 +72,7 @@ Go社区众筹T恤：https://www.tshe.com/c/94c4bfc7
 
 Go社区众筹T恤：https://www.tshe.com/c/94c4bfc7
 招聘：
-【北京】派派 https://gocn.io/article/362
+【北京】派派 https://gocn.vip/topics/8518
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn

--- a/201706/20170612-20170618.md
+++ b/201706/20170612-20170618.md
@@ -8,7 +8,7 @@
 
 * 编辑: 傅小黑 & Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/852
+* GoCN 归档: https://gocn.vip/topics/852
 
 ### GoCN每日新闻(2017-06-13)
 
@@ -27,7 +27,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/858
+* GoCN 归档: https://gocn.vip/topics/858
 
 ### GoCN每日新闻(2017-06-14)
 
@@ -38,7 +38,7 @@
 5. 分布式追踪系统 http://zipkin.io/
 
 招聘：
-【上海】中通快递 https://gocn.io/question/859
+【上海】中通快递 https://gocn.vip/topics/859
 活动预告：
 上海Gopher meetup 报名地址：http://www.bagevent.com/event/569317
 深圳Gopher meetup 报名地址：http://www.bagevent.com/event/575820
@@ -46,7 +46,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/861
+* GoCN 归档: https://gocn.vip/topics/861
 
 ### GoCN每日新闻(2017-06-15)
 
@@ -60,7 +60,7 @@ Go社区众筹T恤：https://www.tshe.com/c/94c4bfc7
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/865
+* GoCN 归档: https://gocn.vip/topics/865
 
 ### GoCN每日新闻(2017-06-16)
 
@@ -76,7 +76,7 @@ Go社区众筹T恤：https://www.tshe.com/c/94c4bfc7
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/866
+* GoCN 归档: https://gocn.vip/topics/866
 
 ### GoCN每日新闻(2017-06-17)
 
@@ -92,7 +92,7 @@ Go社区众筹T恤：https://www.tshe.com/c/94c4bfc7
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/868
+* GoCN 归档: https://gocn.vip/topics/868
 
 ### GoCN每日新闻(2017-06-18)
 
@@ -108,4 +108,4 @@ Go社区众筹T恤：https://www.tshe.com/c/94c4bfc7
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/870
+* GoCN 归档: https://gocn.vip/topics/870

--- a/201706/20170619-20170625.md
+++ b/201706/20170619-20170625.md
@@ -11,7 +11,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/872
+* GoCN 归档: https://gocn.vip/topics/872
 
 ### GoCN每日新闻(2017-06-20)
 
@@ -26,7 +26,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/873
+* GoCN 归档: https://gocn.vip/topics/873
 
 ### GoCN每日新闻(2017-06-21)
 
@@ -41,7 +41,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/876
+* GoCN 归档: https://gocn.vip/topics/876
 
 ### GoCN每日新闻(2017-06-22)
 
@@ -56,7 +56,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/877
+* GoCN 归档: https://gocn.vip/topics/877
 
 ### GoCN每日新闻(2017-06-23)
 
@@ -68,7 +68,7 @@
 
 * 编辑: Asta & 谢烟客
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/878
+* GoCN 归档: https://gocn.vip/topics/878
 
 ### GoCN每日新闻(2017-06-24)
 
@@ -83,7 +83,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/880
+* GoCN 归档: https://gocn.vip/topics/880
 
 ### GoCN每日新闻(2017-06-25)
 
@@ -99,4 +99,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/881
+* GoCN 归档: https://gocn.vip/topics/881

--- a/201706/20170619-20170625.md
+++ b/201706/20170619-20170625.md
@@ -46,7 +46,7 @@
 ### GoCN每日新闻(2017-06-22)
 
 1. Go实现的rsync算法 https://github.com/c4milo/gsync
-2. Golang 中使用 JSON 的小技巧 https://gocn.io/article/363
+2. Golang 中使用 JSON 的小技巧 https://gocn.vip/topics/8519
 3. 数据可视化产生生产力 http://insights.thoughtworkers.org/data-visualization-produce-productivity/
 4. 微服务架构下的安全认证与鉴权 https://mp.weixin.qq.com/s/x0CZpovseOuofTA_lw0HvA
 5. 微服务架构下如何测试 https://martinfowler.com/articles/microservice-testing/

--- a/201706/20170626-20170702.md
+++ b/201706/20170626-20170702.md
@@ -11,7 +11,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/882
+* GoCN 归档: https://gocn.vip/topics/882
 
 ### GoCN每日新闻(2017-06-27)
 
@@ -27,7 +27,7 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/884
+* GoCN 归档: https://gocn.vip/topics/884
 
 ### GoCN每日新闻(2017-06-28)
 
@@ -39,7 +39,7 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/885
+* GoCN 归档: https://gocn.vip/topics/885
 
 ### GoCN每日新闻(2017-06-29)
 
@@ -51,7 +51,7 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/888
+* GoCN 归档: https://gocn.vip/topics/888
 
 ### GoCN每日新闻(2017-06-30)
 
@@ -67,7 +67,7 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/890
+* GoCN 归档: https://gocn.vip/topics/890
 
 ### GoCN每日新闻(2017-07-01)
 
@@ -82,7 +82,7 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/893
+* GoCN 归档: https://gocn.vip/topics/893
 
 ### GoCN每日新闻(2017-07-02)
 
@@ -97,4 +97,4 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/896
+* GoCN 归档: https://gocn.vip/topics/896

--- a/201706/20170626-20170702.md
+++ b/201706/20170626-20170702.md
@@ -15,7 +15,7 @@
 
 ### GoCN每日新闻(2017-06-27)
 
-1. UDP编程的那些事 https://gocn.io/article/371
+1. UDP编程的那些事 https://gocn.vip/topics/8526
 2. Go 1.9 Beta 2 is released! https://golang.org/dl/
 3. C++程序员眼中的Go https://www.murrayc.com/permalink/2017/06/26/a-c-developer-looks-at-go-the-programming-language-part-1-simple-features/
 4. 七牛 Pandora 开发的通用日志收集工具 https://github.com/qiniu/logkit

--- a/201707/20170703-20170709.md
+++ b/201707/20170703-20170709.md
@@ -11,7 +11,7 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/898
+* GoCN 归档: https://gocn.vip/topics/898
 
 ### GoCN每日新闻(2017-07-04)
 
@@ -22,12 +22,12 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 5. Websocket实现原理 http://zeeyang.com/2017/07/02/websocket/
 
 招聘信息：
-腾讯 【深圳】 Go工程师 https://gocn.io/question/900
-阿里 【杭州】 Go工程师 https://gocn.io/question/899
+腾讯 【深圳】 Go工程师 https://gocn.vip/topics/900
+阿里 【杭州】 Go工程师 https://gocn.vip/topics/899
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/901
+* GoCN 归档: https://gocn.vip/topics/901
 
 ### GoCN每日新闻(2017-07-05)
 
@@ -38,12 +38,12 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 5. HttpDns 原理是什么 http://www.linkedkeeper.com/detail/blog.action?bid=171
 
 招聘信息
-【北京】奇虎360 运维工程师 https://gocn.io/question/902
-【北京】奇虎360 开发工程师 https://gocn.io/question/903
+【北京】奇虎360 运维工程师 https://gocn.vip/topics/902
+【北京】奇虎360 开发工程师 https://gocn.vip/topics/903
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/904
+* GoCN 归档: https://gocn.vip/topics/904
 
 ### GoCN每日新闻(2017-07-06)
 
@@ -54,12 +54,12 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 5. 微服务：误解和误用 https://medium.com/@shijuvar/microservices-overview-misinterpretations-and-misuses-56a1979edafb
 
 招聘信息：
-【北京】逻辑思维 https://gocn.io/question/907
-【北京】VMware https://gocn.io/question/906
+【北京】逻辑思维 https://gocn.vip/topics/907
+【北京】VMware https://gocn.vip/topics/906
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/909
+* GoCN 归档: https://gocn.vip/topics/909
 
 ### GoCN每日新闻(2017-07-07)
 
@@ -74,7 +74,7 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/911
+* GoCN 归档: https://gocn.vip/topics/911
 
 ### GoCN每日新闻(2017-07-08)
 
@@ -89,7 +89,7 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/914
+* GoCN 归档: https://gocn.vip/topics/914
 
 ### GoCN每日新闻(2017-07-09)
 
@@ -104,4 +104,4 @@ TiDB技术交流会上海场 Tech Day 时间定在 7 月 8 日，http://tidbtech
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/917
+* GoCN 归档: https://gocn.vip/topics/917

--- a/201707/20170710-20170716.md
+++ b/201707/20170710-20170716.md
@@ -11,7 +11,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/918
+* GoCN 归档: https://gocn.vip/topics/918
 
 ### GoCN每日新闻(2017-07-11)
 
@@ -28,7 +28,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/921
+* GoCN 归档: https://gocn.vip/topics/921
 
 ### GoCN每日新闻(2017-07-12)
 
@@ -45,7 +45,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/924
+* GoCN 归档: https://gocn.vip/topics/924
 
 ### GoCN每日新闻(2017-07-13)
 
@@ -64,7 +64,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/926
+* GoCN 归档: https://gocn.vip/topics/926
 
 ### GoCN每日新闻(2017-07-14)
 
@@ -83,7 +83,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/929
+* GoCN 归档: https://gocn.vip/topics/929
 
 ### GoCN每日新闻(2017-07-15)
 
@@ -98,7 +98,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/933
+* GoCN 归档: https://gocn.vip/topics/933
 
 ### GoCN每日新闻(2017-07-16)
 
@@ -113,4 +113,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/935
+* GoCN 归档: https://gocn.vip/topics/935

--- a/201707/20170710-20170716.md
+++ b/201707/20170710-20170716.md
@@ -22,7 +22,7 @@
 5. 为什么每一个Gopher都应该是数据科学家 http://divan.github.io//talks/2017/06bcn/why_every_gopher_should_be_a_data_scientist.pdf
 
 招聘信息：
-【北京】链家 https://gocn.io/article/381
+【北京】链家 https://gocn.vip/topics/8536
 活动预告：
 杭州Gopher meetup http://www.bagevent.com/event/668296
 
@@ -39,7 +39,7 @@
 5. 使用beego 开发 api server 和前端同学拆分开发，使用swagger http://t.cn/RKx3VIA
 
 招聘信息：
-【北京】360运维工程师 https://gocn.io/article/384
+【北京】360运维工程师 https://gocn.vip/topics/8539
 活动预告：
 杭州Gopher meetup http://www.bagevent.com/event/668296
 
@@ -102,7 +102,7 @@
 
 ### GoCN每日新闻(2017-07-16)
 
-1. Go结构体json的时间格式化解决方案 https://gocn.io/article/388
+1. Go结构体json的时间格式化解决方案 https://gocn.vip/topics/8543
 2. Go优化-自己造log轮子 http://blog.cyeam.com/golang/2017/07/14/go-log
 3. Go泛型大讨论 https://www.reddit.com/r/golang/comments/6nh418/generics_specific_use_cases/
 4. channels 详解 https://speakerdeck.com/kavya719/understanding-channels

--- a/201707/20170717-20170723.md
+++ b/201707/20170717-20170723.md
@@ -22,7 +22,7 @@
 
 活动预告：
 今晚Go实战群图文直播【Go大咖说】 分享第一期——姜家志《比特币、区块链和Go开发》
-https://gocn.io/article/389
+https://gocn.vip/topics/8544
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
@@ -61,11 +61,11 @@ https://gocn.io/article/389
 1. Go怎么写一个网络客户端 https://www.slideshare.net/nats_io/writing-networking-clients-in-go-gophercon-2017-talk
 2. Grumpy入门 https://speakerdeck.com/m157q/20170718-gtg25-introduction-to-grumpy-1
 3. Go面试题答案与解析 https://yushuangqi.com/blog/2017/golang-mian-shi-ti-da-an-yujie-xi.html
-4. pprof简单教程 https://gocn.io/article/394
+4. pprof简单教程 https://gocn.vip/topics/8549
 5. 使用ELK构建分布式日志分析系统 http://www.jianshu.com/p/69ce51cfcb3d
 
 Gopher招聘：
-【深圳】随手记 https://gocn.io/article/396
+【深圳】随手记 https://gocn.vip/topics/8551
 杭州Gopher meetup http://www.bagevent.com/event/668296
 
 * 编辑: Asta
@@ -81,7 +81,7 @@ Gopher招聘：
 5. 给新手的微服务入门知识 https://zhuanlan.zhihu.com/p/28000891
 
 Gopher招聘：
-【上海】Strikingly (YC W13)  https://gocn.io/article/397
+【上海】Strikingly (YC W13)  https://gocn.vip/topics/8552
 杭州Gopher meetup http://www.bagevent.com/event/668296
 
 * 编辑: Asta

--- a/201707/20170717-20170723.md
+++ b/201707/20170717-20170723.md
@@ -10,7 +10,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/936
+* GoCN 归档: https://gocn.vip/topics/936
 
 ### GoCN每日新闻(2017-07-18)
 
@@ -26,7 +26,7 @@ https://gocn.io/article/389
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/943
+* GoCN 归档: https://gocn.vip/topics/943
 
 ### GoCN每日新闻(2017-07-19)
 
@@ -40,7 +40,7 @@ https://gocn.io/article/389
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/947
+* GoCN 归档: https://gocn.vip/topics/947
 
 ### GoCN每日新闻(2017-07-20)
 
@@ -54,7 +54,7 @@ https://gocn.io/article/389
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/951
+* GoCN 归档: https://gocn.vip/topics/951
 
 ### GoCN每日新闻(2017-07-21)
 
@@ -70,7 +70,7 @@ Gopher招聘：
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/953
+* GoCN 归档: https://gocn.vip/topics/953
 
 ### GoCN每日新闻(2017-07-22)
 
@@ -86,7 +86,7 @@ Gopher招聘：
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/956
+* GoCN 归档: https://gocn.vip/topics/956
 
 ### GoCN每日新闻(2017-07-23)
 
@@ -101,4 +101,4 @@ Gopher招聘：
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/959
+* GoCN 归档: https://gocn.vip/topics/959

--- a/201707/20170724-20170730.md
+++ b/201707/20170724-20170730.md
@@ -44,7 +44,7 @@
 ### GoCN每日新闻(2017-07-27)
 
 1. Go 的依赖注入设计 http://adnaan.badr.in/blog/2017/07/15/exploring-dependency-injection-in-go/
-2. golang的gzip优化 https://gocn.io/article/400
+2. golang的gzip优化 https://gocn.vip/topics/8555
 3. 记一次资源泄露之路 https://medium.com/square-corner-blog/always-be-closing-3d5fda0e00da
 4. Go读取股票历史 https://yushuangqi.com/blog/2017/go-du-qu-tong-da-xin-li-shi-ri-xian-shu-ju.html
 5. Go make和new的区别 http://sanyuesha.com/2017/07/26/go-make-and-new/

--- a/201707/20170724-20170730.md
+++ b/201707/20170724-20170730.md
@@ -10,7 +10,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/963
+* GoCN 归档: https://gocn.vip/topics/963
 
 ### GoCN每日新闻(2017-07-25)
 
@@ -25,21 +25,21 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/969
+* GoCN 归档: https://gocn.vip/topics/969
 
 ### GoCN每日新闻(2017-07-26)
 
 1. Go 1.9 RC1 is out https://groups.google.com/forum/#!topic/golang-announce/Zwkj1khBMdI
 2. Go泛型辩论 http://bravenewgeek.com/are-we-there-yet-the-go-generics-debate/
 3. 微服务与API 网关（上）: 为什么需要API网关？ https://mp.weixin.qq.com/s/XTzRr0eR6ybpNFGJ57cVkA
-4. 是否设置多个gopath？ https://gocn.io/question/968
+4. 是否设置多个gopath？ https://gocn.vip/topics/968
 5. 文件管理工具，可单独用也可以当库用 https://github.com/hacdias/filemanager
 
 [8月5日]杭州Gopher meetup http://www.bagevent.com/event/668296
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/974
+* GoCN 归档: https://gocn.vip/topics/974
 
 ### GoCN每日新闻(2017-07-27)
 
@@ -53,7 +53,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/982
+* GoCN 归档: https://gocn.vip/topics/982
 
 ### GoCN每日新闻(2017-07-28)
 
@@ -67,7 +67,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/988
+* GoCN 归档: https://gocn.vip/topics/988
 
 ### GOCN每日新闻(2017-07-29)
 
@@ -81,7 +81,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/993
+* GoCN 归档: https://gocn.vip/topics/993
 
 ### GoCN每日新闻(2017-07-30)
 
@@ -95,4 +95,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/994
+* GoCN 归档: https://gocn.vip/topics/994

--- a/201707/20170731-20170806.md
+++ b/201707/20170731-20170806.md
@@ -11,7 +11,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/995
+* GoCN 归档: https://gocn.vip/topics/995
 
 ### GoCN每日新闻(2017-08-01)
 
@@ -25,7 +25,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/999
+* GoCN 归档: https://gocn.vip/topics/999
 
 ### GoCN每日新闻(2017-08-02)
 
@@ -37,7 +37,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1002
+* GoCN 归档: https://gocn.vip/topics/1002
 
 ### GoCN每日新闻(2017-08-03)
 
@@ -49,7 +49,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1004
+* GoCN 归档: https://gocn.vip/topics/1004
 
 ### GoCN每日新闻(2017-08-04)
 
@@ -61,7 +61,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1009
+* GoCN 归档: https://gocn.vip/topics/1009
 
 ### GoCN每日新闻(2017-08-05)
 
@@ -73,7 +73,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1015
+* GoCN 归档: https://gocn.vip/topics/1015
 
 ### GOCN每日新闻(2017-08-06)
 
@@ -85,4 +85,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1016
+* GoCN 归档: https://gocn.vip/topics/1016

--- a/201707/20170731-20170806.md
+++ b/201707/20170731-20170806.md
@@ -1,7 +1,7 @@
 ### GoCN每日新闻(2017-07-31)
 
-1. 理解Golang并发编程 https://gocn.io/article/404
-2. Go中time.After释放的问题 https://gocn.io/article/403
+1. 理解Golang并发编程 https://gocn.vip/topics/8559
+2. Go中time.After释放的问题 https://gocn.vip/topics/8558
 3. 深入理解Go channel http://legendtkl.com/2017/07/30/understanding-golang-channel/
 4. 可选interface的麻烦 https://blog.merovius.de/2017/07/30/the-trouble-with-optional-interfaces.html
 5. 做一个优秀的程序员到底难在哪里？ https://www.zhihu.com/question/63152623

--- a/201708/20170807-20170813.md
+++ b/201708/20170807-20170813.md
@@ -8,7 +8,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1017
+* GoCN 归档: https://gocn.vip/topics/1017
 
 ### GOCN每日新闻(2017-08-08)
 
@@ -22,7 +22,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1020
+* GoCN 归档: https://gocn.vip/topics/1020
 
 ### GOCN每日新闻(2017-08-09)
 
@@ -34,7 +34,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1025
+* GoCN 归档: https://gocn.vip/topics/1025
 
 ### GOCN每日新闻(2017-08-10)
 
@@ -46,7 +46,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1030
+* GoCN 归档: https://gocn.vip/topics/1030
 
 ### GOCN每日新闻(2017-08-11)
 
@@ -58,7 +58,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1032
+* GoCN 归档: https://gocn.vip/topics/1032
 
 ### GOCN每日新闻(2017-08-12)
 
@@ -73,7 +73,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1037
+* GoCN 归档: https://gocn.vip/topics/1037
 
 ### GOCN每日新闻(2017-08-13)
 
@@ -85,4 +85,4 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1040
+* GoCN 归档: https://gocn.vip/topics/1040

--- a/201708/20170814-20170820.md
+++ b/201708/20170814-20170820.md
@@ -11,7 +11,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1041
+* GoCN 归档: https://gocn.vip/topics/1041
 
 ### GOCN每日新闻(2017-08-15)
 
@@ -23,7 +23,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1044
+* GoCN 归档: https://gocn.vip/topics/1044
 
 ### GOCN每日新闻(2017-08-16)
 
@@ -38,7 +38,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1047
+* GoCN 归档: https://gocn.vip/topics/1047
 
 ### GOCN每日新闻(2017-08-17)
 
@@ -53,7 +53,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1051
+* GoCN 归档: https://gocn.vip/topics/1051
 
 ### GOCN每日新闻(2017-08-18)
 
@@ -68,7 +68,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1054
+* GoCN 归档: https://gocn.vip/topics/1054
 
 ### GOCN每日新闻(2017-08-19)
 
@@ -80,7 +80,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1056
+* GoCN 归档: https://gocn.vip/topics/1056
 
 ### GOCN每日新闻(2017-08-20)
 
@@ -95,4 +95,4 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1058
+* GoCN 归档: https://gocn.vip/topics/1058

--- a/201708/20170821-20170827.md
+++ b/201708/20170821-20170827.md
@@ -8,7 +8,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1061
+* GoCN 归档: https://gocn.vip/topics/1061
 
 ### GOCN每日新闻(2017-08-22)
 
@@ -23,7 +23,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1066
+* GoCN 归档: https://gocn.vip/topics/1066
 
 ### GOCN每日新闻(2017-08-23)
 
@@ -38,7 +38,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1070
+* GoCN 归档: https://gocn.vip/topics/1070
 
 ### GOCN每日新闻(2017-08-24)
 
@@ -52,7 +52,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1073
+* GoCN 归档: https://gocn.vip/topics/1073
 
 ### GoCN每日新闻(2017-08-25)
 
@@ -66,7 +66,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1075
+* GoCN 归档: https://gocn.vip/topics/1075
 
 ### GoCN每日新闻(2017-08-26)
 
@@ -80,7 +80,7 @@ http://www.bagevent.com/event/751233
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1081
+* GoCN 归档: https://gocn.vip/topics/1081
 
 ### GoCN每日新闻(2017-08-27)
 
@@ -92,4 +92,4 @@ http://www.bagevent.com/event/751233
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1083
+* GoCN 归档: https://gocn.vip/topics/1083

--- a/201708/20170828-20170903.md
+++ b/201708/20170828-20170903.md
@@ -8,7 +8,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1085
+* GoCN 归档: https://gocn.vip/topics/1085
 
 ### GoCN每日新闻(2017-08-29)
 
@@ -22,7 +22,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1090
+* GoCN 归档: https://gocn.vip/topics/1090
 
 ### GOCN每日新闻(2017-08-30)
 
@@ -34,7 +34,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1092
+* GoCN 归档: https://gocn.vip/topics/1092
 
 ### GoCN每日新闻(2017-08-31)
 
@@ -48,7 +48,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1095
+* GoCN 归档: https://gocn.vip/topics/1095
 
 ### GOCN每日新闻(2017-09-01)
 
@@ -60,7 +60,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1101
+* GoCN 归档: https://gocn.vip/topics/1101
 
 ### GoCN每日新闻(2017-09-02)
 
@@ -72,7 +72,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1104
+* GoCN 归档: https://gocn.vip/topics/1104
 
 ### GoCN每日新闻(2017-09-03)
 
@@ -84,4 +84,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1106
+* GoCN 归档: https://gocn.vip/topics/1106

--- a/201709/20170904-20170910.md
+++ b/201709/20170904-20170910.md
@@ -8,7 +8,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1107
+* GoCN 归档: https://gocn.vip/topics/1107
 
 ### GoCN每日新闻(2017-09-05)
 
@@ -20,7 +20,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1110
+* GoCN 归档: https://gocn.vip/topics/1110
 
 ### GoCN每日新闻(2017-09-06)
 
@@ -34,7 +34,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1114
+* GoCN 归档: https://gocn.vip/topics/1114
 
 ### GoCN每日新闻(2017-09-07)
 
@@ -46,7 +46,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1118
+* GoCN 归档: https://gocn.vip/topics/1118
 
 ### GoCN每日新闻(2017-09-08)
 
@@ -58,7 +58,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1122
+* GoCN 归档: https://gocn.vip/topics/1122
 
 ### GoCN每日新闻(2017-09-09)
 
@@ -70,7 +70,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1124
+* GoCN 归档: https://gocn.vip/topics/1124
 
 ### GoCN每日新闻(2017-09-10)
 
@@ -82,4 +82,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1127
+* GoCN 归档: https://gocn.vip/topics/1127

--- a/201709/20170911-20170917.md
+++ b/201709/20170911-20170917.md
@@ -8,7 +8,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1129
+* GoCN 归档: https://gocn.vip/topics/1129
 
 ### GoCN每日新闻(2017-09-12)
 
@@ -20,7 +20,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1132
+* GoCN 归档: https://gocn.vip/topics/1132
 
 ### GoCN每日新闻(2017-09-13)
 
@@ -34,7 +34,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1135
+* GoCN 归档: https://gocn.vip/topics/1135
 
 ### GoCN每日新闻(2017-09-14)
 
@@ -48,7 +48,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1136
+* GoCN 归档: https://gocn.vip/topics/1136
 
 ### GoCN每日新闻(2017-09-15)
 
@@ -62,7 +62,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1139
+* GoCN 归档: https://gocn.vip/topics/1139
 
 ### GoCN每日新闻(2017-09-16)
 
@@ -76,7 +76,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1142
+* GoCN 归档: https://gocn.vip/topics/1142
 
 ### GoCN每日新闻(2017-09-17)
 
@@ -90,4 +90,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1144
+* GoCN 归档: https://gocn.vip/topics/1144

--- a/201709/20170918-20170924.md
+++ b/201709/20170918-20170924.md
@@ -10,7 +10,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1147
+* GoCN 归档: https://gocn.vip/topics/1147
 
 ### GoCN每日新闻(2017-09-19)
 
@@ -24,7 +24,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1150
+* GoCN 归档: https://gocn.vip/topics/1150
 
 ### GoCN每日新闻(2017-09-20)
 
@@ -38,7 +38,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1153
+* GoCN 归档: https://gocn.vip/topics/1153
 
 ### GoCN每日新闻(2017-09-21)
 
@@ -52,7 +52,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1155
+* GoCN 归档: https://gocn.vip/topics/1155
 
 ### GoCN每日新闻(2017-09-22)
 
@@ -66,7 +66,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1162
+* GoCN 归档: https://gocn.vip/topics/1162
 
 ### GoCN每日新闻(2017-09-23)
 
@@ -80,7 +80,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1165
+* GoCN 归档: https://gocn.vip/topics/1165
 
 ### GoCN每日新闻(2017-09-24)
 
@@ -94,4 +94,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1169
+* GoCN 归档: https://gocn.vip/topics/1169

--- a/201709/20170925-20171001.md
+++ b/201709/20170925-20171001.md
@@ -10,7 +10,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1171
+* GoCN 归档: https://gocn.vip/topics/1171
 
 ### GoCN每日新闻(2017-09-26)
 
@@ -24,7 +24,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1177
+* GoCN 归档: https://gocn.vip/topics/1177
 
 ### GoCN每日新闻(2017-09-27)
 
@@ -38,7 +38,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1178
+* GoCN 归档: https://gocn.vip/topics/1178
 
 ### GoCN每日新闻(2017-09-28)
 
@@ -52,7 +52,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1183
+* GoCN 归档: https://gocn.vip/topics/1183
 
 ### GoCN每日新闻(2017-09-29)
 
@@ -66,7 +66,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1189
+* GoCN 归档: https://gocn.vip/topics/1189
 
 ### GoCN每日新闻(2017-09-30)
 
@@ -80,7 +80,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1192
+* GoCN 归档: https://gocn.vip/topics/1192
 
 ### GoCN每日新闻(2017-10-01)
 
@@ -94,4 +94,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1194
+* GoCN 归档: https://gocn.vip/topics/1194

--- a/201709/20170925-20171001.md
+++ b/201709/20170925-20171001.md
@@ -2,7 +2,7 @@
 
 1. 微服务的反模式和陷井 http://www.jianshu.com/p/3986239138fe
 2. OpenTracing语义标准规范及实现 http://www.jianshu.com/p/a963ad0bbe3e
-3. 用 500 行 Golang 代码实现高性能的消息回调中间件 https://gocn.io/article/463
+3. 用 500 行 Golang 代码实现高性能的消息回调中间件 https://gocn.vip/topics/8613
 4. 微服务测试 http://www.hamvocke.com/blog/testing-microservices/
 5. Go 在证券行情系统中的应用 https://mp.weixin.qq.com/s/N_mW0UG_q4Oi0VMCahhxCA
 

--- a/201710/20171002-20171008.md
+++ b/201710/20171002-20171008.md
@@ -10,7 +10,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1195
+* GoCN 归档: https://gocn.vip/topics/1195
 
 ### GoCN每日新闻(2017-10-03)
 
@@ -24,7 +24,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1196
+* GoCN 归档: https://gocn.vip/topics/1196
 
 ### GoCN每日新闻(2017-10-04)
 
@@ -36,7 +36,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1197
+* GoCN 归档: https://gocn.vip/topics/1197
 
 ### GoCN每日新闻(2017-10-05)
 
@@ -50,7 +50,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1198
+* GoCN 归档: https://gocn.vip/topics/1198
 
 ### GoCN每日新闻(2017-10-06)
 
@@ -64,7 +64,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1200
+* GoCN 归档: https://gocn.vip/topics/1200
 
 ### GoCN每日新闻(2017-10-07)
 
@@ -78,7 +78,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1201
+* GoCN 归档: https://gocn.vip/topics/1201
 
 ### GoCN每日新闻(2017-10-08)
 
@@ -90,4 +90,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1202
+* GoCN 归档: https://gocn.vip/topics/1202

--- a/201710/20171009-20171015.md
+++ b/201710/20171009-20171015.md
@@ -10,7 +10,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1204
+* GoCN 归档: https://gocn.vip/topics/1204
 
 ### GoCN每日新闻(2017-10-10)
 
@@ -24,7 +24,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1207
+* GoCN 归档: https://gocn.vip/topics/1207
 
 ### GoCN每日新闻(2017-10-11)
 
@@ -36,7 +36,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1210
+* GoCN 归档: https://gocn.vip/topics/1210
 
 ### GOCN每日新闻(2017-10-12)
 
@@ -48,7 +48,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1213
+* GoCN 归档: https://gocn.vip/topics/1213
 
 ### GOCN每日新闻(2017-10-13)
 
@@ -60,7 +60,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1216
+* GoCN 归档: https://gocn.vip/topics/1216
 
 ### GoCN每日新闻(2017-10-14)
 
@@ -72,7 +72,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1218
+* GoCN 归档: https://gocn.vip/topics/1218
 
 ### GoCN每日新闻(2017-10-15)
 
@@ -84,4 +84,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1220
+* GoCN 归档: https://gocn.vip/topics/1220

--- a/201710/20171016-20171022.md
+++ b/201710/20171016-20171022.md
@@ -8,7 +8,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1221
+* GoCN 归档: https://gocn.vip/topics/1221
 
 ### GoCN每日新闻(2017-10-17)
 
@@ -20,7 +20,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1225
+* GoCN 归档: https://gocn.vip/topics/1225
 
 ### GoCN每日新闻(2017-10-18)
 
@@ -32,7 +32,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1226
+* GoCN 归档: https://gocn.vip/topics/1226
 
 ### GoCN每日新闻(2017-10-19)
 
@@ -44,7 +44,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1231
+* GoCN 归档: https://gocn.vip/topics/1231
 
 ### GoCN每日新闻(2017-10-20)
 
@@ -56,7 +56,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1234
+* GoCN 归档: https://gocn.vip/topics/1234
 
 ### GoCN每日新闻(2017-10-21)
 
@@ -68,7 +68,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1235
+* GoCN 归档: https://gocn.vip/topics/1235
 
 ### GoCN每日新闻(2017-10-22)
 
@@ -80,4 +80,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1236
+* GoCN 归档: https://gocn.vip/topics/1236

--- a/201710/20171023-20171029.md
+++ b/201710/20171023-20171029.md
@@ -8,7 +8,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1238
+* GoCN 归档: https://gocn.vip/topics/1238
 
 ### GoCN每日新闻(2017-10-24)
 
@@ -20,7 +20,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1240
+* GoCN 归档: https://gocn.vip/topics/1240
 
 ### GoCN每日新闻(2017-10-25)
 
@@ -32,7 +32,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1246
+* GoCN 归档: https://gocn.vip/topics/1246
 
 ### GoCN每日新闻(2017-10-26)
 
@@ -44,7 +44,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1247
+* GoCN 归档: https://gocn.vip/topics/1247
 
 ### GoCN每日新闻(2017-10-27)
 
@@ -56,7 +56,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1253
+* GoCN 归档: https://gocn.vip/topics/1253
 
 ### GoCN每日新闻(2017-10-28)
 
@@ -68,7 +68,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1255
+* GoCN 归档: https://gocn.vip/topics/1255
 
 ### GoCN每日新闻(2017-10-29)
 
@@ -80,4 +80,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1258
+* GoCN 归档: https://gocn.vip/topics/1258

--- a/201710/20171030-20171105.md
+++ b/201710/20171030-20171105.md
@@ -16,7 +16,7 @@
 2. 使用go tracer优化分形图片制作的性能 https://medium.com/@francesc/using-the-go-execution-tracer-to-speed-up-fractal-rendering-c06bb3760507
 3. gRPC & Protocol Buffer 构建高性能接口实践 http://www.jianshu.com/p/3139e8dd4dd1
 4. Go如何控制CORS https://www.thepolyglotdeveloper.com/2017/10/handling-cors-golang-web-application/
-5. 不得不知道的golang知识点之nil https://gocn.io/article/478
+5. 不得不知道的golang知识点之nil https://gocn.vip/topics/8627
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
@@ -53,7 +53,7 @@
 ### GoCN每日新闻(2017-11-03)
 
 1. 编写终端的UI库 https://github.com/marcusolsson/tui-go
-2. liteide X33发布 https://gocn.io/article/480
+2. liteide X33发布 https://gocn.vip/topics/8629
 3. PingCAP CTO 黄东旭：开源与基础软件创业在中国 https://mp.weixin.qq.com/s/4yTqyvIUC2z3DaDxkpgopg
 4. Go 数据科学 https://blog.chewxy.com/2017/11/02/go-for-data-science/
 5. 类似gofmt的go 模板格式化工具 https://github.com/gotpl/gtfmt

--- a/201710/20171030-20171105.md
+++ b/201710/20171030-20171105.md
@@ -8,7 +8,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1259
+* GoCN 归档: https://gocn.vip/topics/1259
 
 ### GoCN每日新闻(2017-10-31)
 
@@ -20,7 +20,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1262
+* GoCN 归档: https://gocn.vip/topics/1262
 
 ### GoCN每日新闻(2017-11-01)
 
@@ -36,7 +36,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1263
+* GoCN 归档: https://gocn.vip/topics/1263
 
 ### GoCN每日新闻(2017-11-02)
 
@@ -48,7 +48,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1266
+* GoCN 归档: https://gocn.vip/topics/1266
 
 ### GoCN每日新闻(2017-11-03)
 
@@ -60,7 +60,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1273
+* GoCN 归档: https://gocn.vip/topics/1273
 
 ### GoCN每日新闻(2017-11-04)
 
@@ -72,7 +72,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1274
+* GoCN 归档: https://gocn.vip/topics/1274
 
 ### GoCN每日新闻(2017-11-05)
 
@@ -84,4 +84,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1275
+* GoCN 归档: https://gocn.vip/topics/1275

--- a/201711/20171106-20171112.md
+++ b/201711/20171106-20171112.md
@@ -8,7 +8,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1279
+* GoCN 归档: https://gocn.vip/topics/1279
 
 ### GoCN每日新闻(2017-11-07)
 
@@ -20,7 +20,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1285
+* GoCN 归档: https://gocn.vip/topics/1285
 
 ### GoCN每日新闻(2017-11-08)
 
@@ -32,7 +32,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1288
+* GoCN 归档: https://gocn.vip/topics/1288
 
 ### GoCN每日新闻(2017-11-09)
 
@@ -44,7 +44,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1291
+* GoCN 归档: https://gocn.vip/topics/1291
 
 ### GoCN每日新闻(2017-11-10)
 
@@ -56,7 +56,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1292
+* GoCN 归档: https://gocn.vip/topics/1292
 
 ### GoCN每日新闻(2017-11-11)
 
@@ -68,7 +68,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1296
+* GoCN 归档: https://gocn.vip/topics/1296
 
 ### GoCN每日新闻(2017-11-12)
 
@@ -80,4 +80,4 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1298
+* GoCN 归档: https://gocn.vip/topics/1298

--- a/201711/20171113-20171119.md
+++ b/201711/20171113-20171119.md
@@ -8,7 +8,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1301
+* GoCN 归档: https://gocn.vip/topics/1301
 
 ### GOCN每日新闻(2017-11-14)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1308
+* GoCN 归档: https://gocn.vip/topics/1308
 
 ### GOCN每日新闻(2017-11-15)
 
@@ -32,7 +32,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1313
+* GoCN 归档: https://gocn.vip/topics/1313
 
 ### GOCN每日新闻(2017-11-16)
 
@@ -44,7 +44,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1321
+* GoCN 归档: https://gocn.vip/topics/1321
 
 ### GoCN每日新闻(2017-11-17)
 
@@ -56,7 +56,7 @@
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1327
+* GoCN 归档: https://gocn.vip/topics/1327
 
 ### GoCN每日新闻(2017-11-18)
 
@@ -68,7 +68,7 @@
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1329
+* GoCN 归档: https://gocn.vip/topics/1329
 
 ### GoCN每日新闻(2017-11-19)
 
@@ -80,4 +80,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1332
+* GoCN 归档: https://gocn.vip/topics/1332

--- a/201711/20171120-20171126.md
+++ b/201711/20171120-20171126.md
@@ -8,7 +8,7 @@
 
 * 编辑: small_fish__
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1333
+* GoCN 归档: https://gocn.vip/topics/1333
 
 ### GoCN每日新闻(2017-11-21)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 薛锦
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1335
+* GoCN 归档: https://gocn.vip/topics/1335
 
 ### GoCN每日新闻(2017-11-22)
 
@@ -32,7 +32,7 @@
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1338
+* GoCN 归档: https://gocn.vip/topics/1338
 
 ### GoCN每日新闻(2017-11-23)
 
@@ -44,7 +44,7 @@
 
 * 编辑: 崔广章
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1342
+* GoCN 归档: https://gocn.vip/topics/1342
 
 ### GoCN每日新闻(2017-11-24)
 
@@ -56,7 +56,7 @@
 
 * 编辑: 何小云
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1345
+* GoCN 归档: https://gocn.vip/topics/1345
 
 ### GoCN每日新闻(2017-11-25)
 
@@ -68,7 +68,7 @@
 
 * 编辑: 刘力
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1347
+* GoCN 归档: https://gocn.vip/topics/1347
 
 ### GoCN每日新闻(2017-11-26)
 
@@ -80,4 +80,4 @@
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1349
+* GoCN 归档: https://gocn.vip/topics/1349

--- a/201711/20171127-20171203.md
+++ b/201711/20171127-20171203.md
@@ -8,7 +8,7 @@
 
 * 编辑: Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1353
+* GoCN 归档: https://gocn.vip/topics/1353
 
 ### GOCN每日新闻(2017-11-28)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1354
+* GoCN 归档: https://gocn.vip/topics/1354
 
 ### GOCN每日新闻(2017-11-29)
 
@@ -32,7 +32,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1358
+* GoCN 归档: https://gocn.vip/topics/1358
 
 ### GOCN每日新闻(2017-11-30)
 
@@ -44,7 +44,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1361
+* GoCN 归档: https://gocn.vip/topics/1361
 
 ### GoCN每日新闻(2017-12-01)
 
@@ -56,7 +56,7 @@
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1366
+* GoCN 归档: https://gocn.vip/topics/1366
 
 ### GoCN每日新闻(2017-12-02)
 
@@ -68,7 +68,7 @@
 
 * 编辑: 马怀博
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1369
+* GoCN 归档: https://gocn.vip/topics/1369
 
 ### GoCN每日新闻(2017-12-03)
 
@@ -80,4 +80,4 @@
 
 * 编辑: 卢炜豪
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1372
+* GoCN 归档: https://gocn.vip/topics/1372

--- a/201712/20171204-20171210.md
+++ b/201712/20171204-20171210.md
@@ -8,7 +8,7 @@
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1374
+* GoCN 归档: https://gocn.vip/topics/1374
 
 ### GoCN每日新闻(2017-12-05)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 薛锦
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1376
+* GoCN 归档: https://gocn.vip/topics/1376
 
 ### GoCN每日新闻(2017-12-06)
 
@@ -32,7 +32,7 @@
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1380
+* GoCN 归档: https://gocn.vip/topics/1380
 
 ### GoCN每日新闻(2017-12-07)
 
@@ -44,7 +44,7 @@
 
 * 编辑: 崔广章
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1383
+* GoCN 归档: https://gocn.vip/topics/1383
 
 ### GoCN每日新闻(2017-12-08)
 
@@ -56,7 +56,7 @@
 
 * 编辑: 何小云
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1388
+* GoCN 归档: https://gocn.vip/topics/1388
 
 ### GoCN每日新闻(2017-12-09)
 
@@ -68,7 +68,7 @@
 
 * 编辑: 刘力
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1392
+* GoCN 归档: https://gocn.vip/topics/1392
 
 ### GoCN每日新闻(2017-12-10)
 
@@ -80,4 +80,4 @@
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1393
+* GoCN 归档: https://gocn.vip/topics/1393

--- a/201712/20171211-20171217.md
+++ b/201712/20171211-20171217.md
@@ -8,7 +8,7 @@
 
 * 编辑: Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1396
+* GoCN 归档: https://gocn.vip/topics/1396
 
 ### GOCN每日新闻(2017-12-12)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1399
+* GoCN 归档: https://gocn.vip/topics/1399
 
 ### GOCN每日新闻(2017-12-13)
 
@@ -32,7 +32,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1402
+* GoCN 归档: https://gocn.vip/topics/1402
 
 ### GOCN每日新闻(2017-12-14)
 
@@ -44,7 +44,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1406
+* GoCN 归档: https://gocn.vip/topics/1406
 
 ### GoCN每日新闻(2017-12-15)
 
@@ -56,7 +56,7 @@
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1407
+* GoCN 归档: https://gocn.vip/topics/1407
 
 ### GoCN每日新闻(2017-12-16)
 
@@ -68,7 +68,7 @@
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1410
+* GoCN 归档: https://gocn.vip/topics/1410
 
 ### GoCN每日新闻(2017-12-17)
 
@@ -80,4 +80,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1412
+* GoCN 归档: https://gocn.vip/topics/1412

--- a/201712/20171218-20171224.md
+++ b/201712/20171218-20171224.md
@@ -11,7 +11,7 @@
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1413
+* GoCN 归档: https://gocn.vip/topics/1413
 
 ### GoCN每日新闻(2017-12-19)
 
@@ -23,7 +23,7 @@
 
 * 编辑: 薛锦
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1416
+* GoCN 归档: https://gocn.vip/topics/1416
 
 ### GoCN每日新闻(2017-12-20)
 
@@ -35,7 +35,7 @@
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1418
+* GoCN 归档: https://gocn.vip/topics/1418
 
 ### GoCN每日新闻(2017-12-21)
 
@@ -47,7 +47,7 @@
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1422
+* GoCN 归档: https://gocn.vip/topics/1422
 
 ### GoCN每日新闻(2017-12-22)
 
@@ -59,7 +59,7 @@
 
 * 编辑: Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1423
+* GoCN 归档: https://gocn.vip/topics/1423
 
 ### GoCN每日新闻(2017-12-23)
 
@@ -71,7 +71,7 @@
 
 * 编辑: 刘力
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1426
+* GoCN 归档: https://gocn.vip/topics/1426
 
 ### GoCN每日新闻(2017-12-24)
 
@@ -83,4 +83,4 @@
 
 * 编辑: 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1428
+* GoCN 归档: https://gocn.vip/topics/1428

--- a/201712/20171225-20171231.md
+++ b/201712/20171225-20171231.md
@@ -8,7 +8,7 @@
 
 * 编辑: Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1431
+* GoCN 归档: https://gocn.vip/topics/1431
 
 ### GOCN每日新闻(2017-12-26)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1433
+* GoCN 归档: https://gocn.vip/topics/1433
 
 ### GoCN每日新闻(2017-12-27)
 
@@ -32,7 +32,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1435
+* GoCN 归档: https://gocn.vip/topics/1435
 
 ### GoCN每日新闻(2017-12-28)
 
@@ -44,7 +44,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1439
+* GoCN 归档: https://gocn.vip/topics/1439
 
 ### GoCN每日新闻(2017-12-29)
 
@@ -59,7 +59,7 @@
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1440
+* GoCN 归档: https://gocn.vip/topics/1440
 
 ### GoCN每日新闻(2017-12-30)
 
@@ -74,7 +74,7 @@ GopherChina2018来了！ https://www.bagevent.com/event/1086224
 
 * 编辑: 马怀博
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1442
+* GoCN 归档: https://gocn.vip/topics/1442
 
 ### GoCN每日新闻(2017-12-31)
 
@@ -89,4 +89,4 @@ GopherChina2018来了！ https://www.bagevent.com/event/1086224
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1444
+* GoCN 归档: https://gocn.vip/topics/1444

--- a/201801/20180101-20180107.md
+++ b/201801/20180101-20180107.md
@@ -87,7 +87,7 @@ GopherChina2018来了！ https://www.bagevent.com/event/1086224
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.io/m/question/1458
+* GoCN归档：https://gocn.vip/topics/1458
 
 ## GoCN每日新闻(2018-01-07)
 

--- a/201801/20180101-20180107.md
+++ b/201801/20180101-20180107.md
@@ -11,7 +11,7 @@ GopherChina2018来了！ https://www.bagevent.com/event/1086224
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1445
+* GoCN 归档: https://gocn.vip/topics/1445
 
 ## GoCN每日新闻(2018-01-02)
 
@@ -26,7 +26,7 @@ GopherChina2018来了！ https://www.bagevent.com/event/1086224
 
 * 编辑: 薛锦
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1447
+* GoCN 归档: https://gocn.vip/topics/1447
 
 ## GoCN每日新闻(2018-01-03)
 
@@ -41,7 +41,7 @@ GopherChina2018来了！ https://www.bagevent.com/event/1086224
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1449
+* GoCN 归档: https://gocn.vip/topics/1449
 
 ## GoCN每日新闻(2018-01-04)
 
@@ -56,7 +56,7 @@ GopherChina2018来了！ https://www.bagevent.com/event/1086224
 
 * 编辑: 崔广章
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1456
+* GoCN 归档: https://gocn.vip/topics/1456
 
 
 ## GoCN每日新闻(2018-01-05)
@@ -72,7 +72,7 @@ GopherChina2018来了！ https://www.bagevent.com/event/1086224
 
 * 编辑: 何小云
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1457
+* GoCN归档: https://gocn.vip/topics/1457
 
 ## GoCN每日新闻(2018-01-06)
 

--- a/201801/20180108-20180114.md
+++ b/201801/20180108-20180114.md
@@ -28,7 +28,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.io/question/1467
+* GoCN归档：https://gocn.vip/topics/1467
 
 ## GoCN每日新闻(2018-01-10)
 
@@ -44,7 +44,7 @@
 
 * 编辑：yulibaozi
 * 订阅新闻：http://tinyletter.com/gocn
-* GoCN归档：https://gocn.io/question/1469
+* GoCN归档：https://gocn.vip/topics/1469
 
 
 ## GoCN每日新闻(2018-01-11)
@@ -78,7 +78,7 @@
 
 * 编辑:Razil
 * 订阅新闻: http://tinyletter.com/gocn 
-* GoCN归档: https://gocn.io/question/1474 
+* GoCN归档: https://gocn.vip/topics/1474 
 
 ## GoCN每日新闻(2018-01-13)
 
@@ -93,7 +93,7 @@
 
 * 编辑:马怀博
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1479
+* GoCN归档: https://gocn.vip/topics/1479
 
 ## GoCN每日新闻(2018-01-14)
 
@@ -109,6 +109,6 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1480
+* GoCN归档: https://gocn.vip/topics/1480
 
 

--- a/201801/20180108-20180114.md
+++ b/201801/20180108-20180114.md
@@ -61,7 +61,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/article/557
+* GoCN归档: https://gocn.vip/topics/8692
 
 
 

--- a/201801/20180115-20180121.md
+++ b/201801/20180115-20180121.md
@@ -11,7 +11,7 @@ GopherChina2018 来了！ https://www.bagevent.com/event/1086224
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1482
+* GoCN 归档: https://gocn.vip/topics/1482
 
 ## GoCN 每日新闻(2018-01-16)
 
@@ -26,7 +26,7 @@ GopherChina2018 来了！ https://www.bagevent.com/event/1086224
 
 * 编辑: 薛锦
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1485
+* GoCN 归档: https://gocn.vip/topics/1485
 
 ## GoCN每日新闻(2018-01-17)
 
@@ -42,7 +42,7 @@ GopherChina 2018 讲师招募 https://jinshuju.net/f/fpdzI9
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1488
+* GoCN归档: https://gocn.vip/topics/1488
 
 ## GoCN每日新闻(2018-01-18)
 
@@ -58,7 +58,7 @@ GopherChina 2018 讲师招募 https://jinshuju.net/f/fpdzI9
 
 * 编辑: 崔广章
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:https://gocn.io/question/1490
+* GoCN归档:https://gocn.vip/topics/1490
 
 ## GoCN每日新闻(2018-01-19)
 
@@ -73,7 +73,7 @@ GopherChina 2018 早鸟票即将售罄 https://www.bagevent.com/event/1086224
 
 * 编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:https://gocn.io/question/1496
+* GoCN归档:https://gocn.vip/topics/1496
 
 ## GoCN每日新闻(2018-01-20)
 
@@ -88,7 +88,7 @@ GopherChina 2018 早鸟票即将售罄 https://www.bagevent.com/event/1086224
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:https://gocn.io/question/1498
+* GoCN归档:https://gocn.vip/topics/1498
 
 ## GoCN每日新闻(2018-01-21)
 
@@ -103,4 +103,4 @@ GopherChina 2018 早鸟票即将售罄 https://www.bagevent.com/event/1086224
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:https://gocn.io/question/1500
+* GoCN归档:https://gocn.vip/topics/1500

--- a/201801/20180122-20180128.md
+++ b/201801/20180122-20180128.md
@@ -8,14 +8,14 @@
 
 招聘信息：
 1. [上海/北京]北明软件(A股上市公司) 招聘go开发主管/架构师 https://gocn.io/article/572
-2. [北京/杭州]滴滴云 招聘云计算各领域人才 https://gocn.io/question/1481
+2. [北京/杭州]滴滴云 招聘云计算各领域人才 https://gocn.vip/topics/1481
 
 活动预告：
 GopherChina 2018 早鸟票即将售罄 https://www.bagevent.com/event/1086224
 
 * 编辑: Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.io/question/1502
+* GoCN归档：https://gocn.vip/topics/1502
 
 ## GoCN每日新闻(2018-01-23)
 
@@ -44,12 +44,12 @@ GopherChina Telegram群现已上线 https://t.me/gopherchina
 Tips：
 * GopherChina2018来了！ https://www.bagevent.com/event/1086224
 * GopherChina Telegram群现已上线 https://t.me/gopherchina 
-* 【北京】知乎招聘Go架构师 https://gocn.io/question/1513
+* 【北京】知乎招聘Go架构师 https://gocn.vip/topics/1513
 * 【北京】云账户招聘Go高级工程师 https://gocn.io/article/579
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.io/question/1514
+* GoCN归档：https://gocn.vip/topics/1514
 
 
 ### GoCN每日新闻(2018-01-25)
@@ -63,12 +63,12 @@ Tips：
 Tips：
 * GopherChina2018来了！ https://www.bagevent.com/event/1086224
 * GopherChina Telegram群现已上线 https://t.me/gopherchina 
-* 【北京】盖娅互娱招聘~GO语言开发工程师 https://gocn.io/question/1515
+* 【北京】盖娅互娱招聘~GO语言开发工程师 https://gocn.vip/topics/1515
 
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1518
+* GoCN归档: https://gocn.vip/topics/1518
 
 ### GoCN每日新闻(2018-01-26)
 
@@ -85,7 +85,7 @@ Tips：
 
 * 编辑:Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1522
+* GoCN归档: https://gocn.vip/topics/1522
 
 ### GoCN每日新闻(2018-01-27)
 
@@ -98,12 +98,12 @@ Tips：
 Tips：
 * GopherChina2018来了！ https://www.bagevent.com/event/1086224
 * GopherChina Telegram群现已上线 https://t.me/gopherchina
-* [北京]滴滴招聘golang工程师-特征系统[长期] https://gocn.io/question/766
+* [北京]滴滴招聘golang工程师-特征系统[长期] https://gocn.vip/topics/766
 
 
 * 编辑:马怀博
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1528
+* GoCN归档: https://gocn.vip/topics/1528
 
 ### GoCN每日新闻(2018-01-28)
 
@@ -122,4 +122,4 @@ Tips：
 
 * 编辑: 卢炜豪
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1529
+* GoCN归档: https://gocn.vip/topics/1529

--- a/201801/20180122-20180128.md
+++ b/201801/20180122-20180128.md
@@ -109,7 +109,7 @@ Tips：
 
 1. 写Go代码时遇到的那些问题[第2期]  http://tonybai.com/2018/01/27/the-problems-i-encountered-when-writing-go-code-issue-2nd/
 2. 并发其实更慢？https://pocketgophers.com/concurrency-slower/
-3. 基于log4go的下一代日志系统  https://gocn.io/article/592
+3. 基于log4go的下一代日志系统  https://gocn.vip/topics/8725
 4. 使用Go 1.10中新的跟踪功能进行集成测试的调试 https://medium.com/@cep21/using-go-1-10-new-trace-features-to-debug-an-integration-test-1dc39e4e812d
 5. 软件工程师需要了解的网络知识：从铜线到HTTP（一） https://lvwenhan.com/操作系统/485.html 
 

--- a/201801/20180129-20180204.md
+++ b/201801/20180129-20180204.md
@@ -13,7 +13,7 @@ Tips：
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1534
+* GoCN 归档: https://gocn.vip/topics/1534
 
 ### GoCN 每日新闻(2018-01-30)
 
@@ -30,7 +30,7 @@ Tips:
 
 * 编辑: 薛锦
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.io/question/1536
+* GoCN 归档: https://gocn.vip/topics/1536
 
 ### GoCN每日新闻(2018-01-31)
 
@@ -44,7 +44,7 @@ Tips:
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1538
+* GoCN归档: https://gocn.vip/topics/1538
 
 ### GoCN每日新闻(2018-02-01)
 
@@ -68,7 +68,7 @@ Tips:
 
 * 编辑: Asta & 崔广章
 * 订阅新闻: http://tinyletter.com/gocn
-* 归档地址：https://gocn.io/question/1543
+* 归档地址：https://gocn.vip/topics/1543
 
 ### GoCN每日新闻(2018-02-02)
 
@@ -84,7 +84,7 @@ Tips：
 
 * 编辑: 何小云
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1547
+* GoCN归档: https://gocn.vip/topics/1547
 
 ### GoCN每日新闻(2018-02-03)
 
@@ -100,7 +100,7 @@ Tips：
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1553
+* GoCN归档: https://gocn.vip/topics/1553
 
 ### GoCN每日新闻(2018-02-04)
 
@@ -116,4 +116,4 @@ Tips：
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.io/question/1558
+* GoCN归档：https://gocn.vip/topics/1558

--- a/201802/20180205-20180211.md
+++ b/201802/20180205-20180211.md
@@ -91,7 +91,7 @@ Tips：
 2. node开发者学习Go https://nemethgergely.com/learning-go-as-a-nodejs-developer/
 3. golang80行代码钉钉群机器人订阅百度新闻 https://segmentfault.com/a/1190000013241676
 4. 如何实现一个 go packages 的开源镜像站？https://hacpai.com/article/1518099877343
-5. Go 内嵌静态文件工具 packr https://gocn.io/article/612
+5. Go 内嵌静态文件工具 packr https://gocn.vip/topics/8744
 
 活动信息：
 * 第四届 GopherChina 大会(上海 04-14 ~ 04-15)强势来袭，和大牛面对面，请戳我: https://www.bagevent.com/event/1086224

--- a/201802/20180205-20180211.md
+++ b/201802/20180205-20180211.md
@@ -12,7 +12,7 @@
 
 编辑: Kevin    
 订阅新闻: http://tinyletter.com/gocn    
-GoCN归档：https://gocn.io/question/1559    
+GoCN归档：https://gocn.vip/topics/1559    
 
 
 ## GoCN每日新闻(2018-02-06)
@@ -32,7 +32,7 @@ GoCN归档：https://gocn.io/question/1559
 
  编辑: Asta
 * 订阅新闻: http://tinyletter.com/gocn    
-* GoCN归档：https://gocn.io/question/1564  
+* GoCN归档：https://gocn.vip/topics/1564  
 
 
 ## GoCN每日新闻(2018-02-07)
@@ -49,7 +49,7 @@ Tips：
 
 编辑: 李森森
 * 订阅新闻:http://tinyletter.com/gocn
-* GoCN归档:https://gocn.io/question/1567
+* GoCN归档:https://gocn.vip/topics/1567
 
 
 
@@ -67,7 +67,7 @@ Tips：
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.io/question/1571
+* GoCN归档：https://gocn.vip/topics/1571
 
 ## GoCN每日新闻(2018-02-09)
 
@@ -83,7 +83,7 @@ Tips：
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:  https://gocn.io/question/1574
+* GoCN归档:  https://gocn.vip/topics/1574
 
 ## GoCN每日新闻(2018-02-10)
 
@@ -99,7 +99,7 @@ Tips：
 
 * 编辑:马怀博
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1581
+* GoCN归档: https://gocn.vip/topics/1581
 
 ## GoCN每日新闻(2018-02-11)
 
@@ -113,4 +113,4 @@ Tips：
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:  https://gocn.io/question/1582
+* GoCN归档:  https://gocn.vip/topics/1582

--- a/201802/20180212-20180218.md
+++ b/201802/20180212-20180218.md
@@ -12,7 +12,7 @@ https://www.eduonix.com/blog/database/mongodb-couchdb-nosql-database-choose/
 
 * 编辑: 薛锦
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:  https://gocn.io/question/1584
+* GoCN归档:  https://gocn.vip/topics/1584
 
 ## GoCN每日新闻(2018-02-13)
 
@@ -26,7 +26,7 @@ https://www.eduonix.com/blog/database/mongodb-couchdb-nosql-database-choose/
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:  https://gocn.io/question/1585
+* GoCN归档:  https://gocn.vip/topics/1585
 
 ## GoCN每日新闻(2018-02-14)
 
@@ -40,7 +40,7 @@ https://www.eduonix.com/blog/database/mongodb-couchdb-nosql-database-choose/
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1586
+* GoCN归档: https://gocn.vip/topics/1586
 
 ## GoCN每日新闻(2018-02-15)
 
@@ -54,7 +54,7 @@ https://www.eduonix.com/blog/database/mongodb-couchdb-nosql-database-choose/
 
 * 编辑: 崔广章
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1587
+* GoCN归档: https://gocn.vip/topics/1587
 
 ## GoCN每日新闻(2018-02-16)【新年快乐!】
 
@@ -70,7 +70,7 @@ https://www.eduonix.com/blog/database/mongodb-couchdb-nosql-database-choose/
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1588
+* GoCN归档: https://gocn.vip/topics/1588
 
 
 ## GoCN每日新闻(2018-02-17)
@@ -87,7 +87,7 @@ https://blog.golang.org/go1.10
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1589
+* GoCN归档: https://gocn.vip/topics/1589
 
 ## GoCN每日新闻(2018-02-18)
 
@@ -101,5 +101,5 @@ https://blog.golang.org/go1.10
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1591
+* GoCN归档: https://gocn.vip/topics/1591
 

--- a/201802/20180219-20180225.md
+++ b/201802/20180219-20180225.md
@@ -11,7 +11,7 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 编辑: 李俱顺Kevin    
 订阅新闻: http://tinyletter.com/gocn    
-GoCN归档: https://gocn.io/question/1593   
+GoCN归档: https://gocn.vip/topics/1593   
 
 
 ## GoCN每日新闻(2018-02-22)
@@ -26,7 +26,7 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1597
+* GoCN归档: https://gocn.vip/topics/1597
 
 ## GoCN每日新闻(2018-02-23)
 
@@ -40,7 +40,7 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑:Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1598
+* GoCN归档: https://gocn.vip/topics/1598
 
 ## GoCN每日新闻(2018-02-24)
 
@@ -54,7 +54,7 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑:马怀博
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1604
+* GoCN归档: https://gocn.vip/topics/1604
 
 ## GoCN每日新闻(2018-02-25)
 
@@ -66,4 +66,4 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑: 卢炜豪
 * 订阅新闻:  http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1609
+* GoCN归档: https://gocn.vip/topics/1609

--- a/201802/20180226-20180304.md
+++ b/201802/20180226-20180304.md
@@ -10,7 +10,7 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1611
+* GoCN归档: https://gocn.vip/topics/1611
 
 ## GoCN每日新闻(2018-02-27)
 
@@ -24,12 +24,12 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑: 薛锦
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:  https://gocn.io/question/1616
+* GoCN归档:  https://gocn.vip/topics/1616
 
 ## GoCN每日新闻(2018-02-28)
 
 1. Go2017年问卷调查结果 https://blog.golang.org/survey2017-results
-2. Go零基础编程入门教程 https://gocn.io/question/1615
+2. Go零基础编程入门教程 https://gocn.vip/topics/1615
 3. 跨平台编译cgo https://github.com/karalabe/xgo
 4. 200行Go实现一个以太坊代理服务器 https://zhuanlan.zhihu.com/p/34056983
 5. Go addressable http://colobu.com/2018/02/27/go-addressable/
@@ -38,7 +38,7 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:  https://gocn.io/question/1621
+* GoCN归档:  https://gocn.vip/topics/1621
 
 
 ## GoCN每日新闻(2018-03-01)
@@ -54,7 +54,7 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑: 崔广章
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档:  https://gocn.io/question/1625
+* GoCN归档:  https://gocn.vip/topics/1625
 
 
 ##  GoCN每日新闻(2018-03-02) 【元宵节快乐!】
@@ -69,7 +69,7 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑: 何小云
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://www.gocn.io/question/1628
+* GoCN归档: https://www.gocn.vip/topics/1628
 
 
 ## GoCN每日新闻(2018-03-03)
@@ -84,7 +84,7 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1631
+* GoCN归档: https://gocn.vip/topics/1631
 
 ## GoCN每日新闻(2018-03-04)
 
@@ -98,4 +98,4 @@ GopherChina 2018 大会全部议程出来了 https://mp.weixin.qq.com/s/1_v8Dsvi
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1635
+* GoCN归档: https://gocn.vip/topics/1635

--- a/201803/20180305-20180311.md
+++ b/201803/20180305-20180311.md
@@ -10,7 +10,7 @@
 
 编辑: 李俱顺Kevin    
 订阅新闻: http://tinyletter.com/gocn    
-GoCN归档: https://gocn.io/question/1637    
+GoCN归档: https://gocn.vip/topics/1637    
 
 
 
@@ -26,7 +26,7 @@ GoCN归档: https://gocn.io/question/1637
 
 编辑: 傅小黑  
 订阅新闻: http://tinyletter.com/gocn  
-GoCN归档: https://gocn.io/question/1640  
+GoCN归档: https://gocn.vip/topics/1640  
 
 ## GoCN每日新闻(2018-03-07)
 
@@ -40,7 +40,7 @@ GoCN归档: https://gocn.io/question/1640
 
 编辑: yulibaozi  
 订阅新闻: http://tinyletter.com/gocn  
-GoCN归档: https://gocn.io/question/1643  
+GoCN归档: https://gocn.vip/topics/1643  
 
 
 
@@ -56,7 +56,7 @@ GoCN归档: https://gocn.io/question/1643
 
 编辑: 李森森  
 订阅新闻:http://tinyletter.com/gocn  
-GoCN归档:https://gocn.io/question/1648  
+GoCN归档:https://gocn.vip/topics/1648  
 
 ## GoCN每日新闻(2018-03-09)
 
@@ -69,12 +69,12 @@ GoCN归档:https://gocn.io/question/1648
 Tip: Go语言知识图谱 https://mp.weixin.qq.com/s/SmKxLsa2grc7kYj7eYyidQ
 
 招聘信息:
-1.【北京】【商汤科技】招聘 Golang/Java/C++ 工程师 https://gocn.io/question/1629  
-2.【北京】【小川在线】招Go工程师 https://gocn.io/question/1654  
+1.【北京】【商汤科技】招聘 Golang/Java/C++ 工程师 https://gocn.vip/topics/1629  
+2.【北京】【小川在线】招Go工程师 https://gocn.vip/topics/1654  
 
 编辑:Razil  
 订阅新闻: http://tinyletter.com/gocn  
-GoCN归档: https://gocn.io/question/1655
+GoCN归档: https://gocn.vip/topics/1655
 
 ## GoCN每日新闻(2018-03-10)
 
@@ -88,7 +88,7 @@ Tip: Go语言知识图谱 https://mp.weixin.qq.com/s/SmKxLsa2grc7kYj7eYyidQ
 
 招聘信息:
 
-1.【北京】【Momenta招聘】无人驾驶公司招聘Go https://gocn.io/question/1432
+1.【北京】【Momenta招聘】无人驾驶公司招聘Go https://gocn.vip/topics/1432
 
 2.【北京】【蚂蚁金服】Golang技术专家 https://gocn.io/article/641
 
@@ -96,7 +96,7 @@ Tip: Go语言知识图谱 https://mp.weixin.qq.com/s/SmKxLsa2grc7kYj7eYyidQ
 
 订阅新闻: http://tinyletter.com/gocn
 
-GoCN归档: https://gocn.io/question/1662
+GoCN归档: https://gocn.vip/topics/1662
 
 ## GoCN每日新闻(2018-03-11)
 
@@ -110,7 +110,7 @@ Tip: Go语言知识图谱 https://mp.weixin.qq.com/s/SmKxLsa2grc7kYj7eYyidQ
 
 招聘信息:
 
-1.【杭州】杭州云柚科技招聘Golang架构师 https://gocn.io/question/1652
+1.【杭州】杭州云柚科技招聘Golang架构师 https://gocn.vip/topics/1652
 
 2.【广州】sunday morning 招聘后端工程师 https://gocn.io/article/649
 
@@ -118,4 +118,4 @@ Tip: Go语言知识图谱 https://mp.weixin.qq.com/s/SmKxLsa2grc7kYj7eYyidQ
 
 订阅新闻: http://tinyletter.com/gocn
 
-GoCN归档: https://gocn.io/question/1665
+GoCN归档: https://gocn.vip/topics/1665

--- a/201803/20180312-20180318.md
+++ b/201803/20180312-20180318.md
@@ -9,7 +9,7 @@
 
 - 编辑: Asta
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.io/question/1668
+- GoCN归档: https://gocn.vip/topics/1668
 
 ## GoCN每日新闻(2018-03-13)
 
@@ -23,7 +23,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档:  https://gocn.io/question/1672
+- GoCN归档:  https://gocn.vip/topics/1672
 
 ## GoCN每日新闻(2018-03-14)
 
@@ -37,7 +37,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档:  https://gocn.io/question/1678
+- GoCN归档:  https://gocn.vip/topics/1678
 
 
 ## GoCN每日新闻(2018-03-15)
@@ -53,7 +53,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档:  https://gocn.io/question/1686
+- GoCN归档:  https://gocn.vip/topics/1686
 
 
 ## GoCN每日新闻(2018-03-16)
@@ -68,7 +68,7 @@
 
 - 编辑: 何小云
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.io/question/1690
+- GoCN归档: https://gocn.vip/topics/1690
 
 ## GoCN每日新闻(2018-03-17)
 
@@ -82,7 +82,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.io/question/1692
+- GoCN归档: https://gocn.vip/topics/1692
 
 ## GoCN每日新闻(2018-03-18)
 
@@ -96,4 +96,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.io/question/1696
+- GoCN归档: https://gocn.vip/topics/1696

--- a/201803/20180319-20180325.md
+++ b/201803/20180319-20180325.md
@@ -4,11 +4,11 @@
 2. GopherChina大会嘉宾专访--hyper CTO 王旭 https://mp.weixin.qq.com/s/n_ayU2z53h6I7cRSrFGPyA
 3. GopherChina大会嘉宾专访--NEO区块链架构师 丛宏雷 https://mp.weixin.qq.com/s/BO0eIz99pBzli5ygY082XA
 4. GopherChina 国外讲师William带来Go高级培训  https://mp.weixin.qq.com/s/e7pH2YtjUg7-oBdLR9tDLA
-5. Go Wednesday活动提案 https://gocn.io/question/1677
+5. Go Wednesday活动提案 https://gocn.vip/topics/1677
 
 编辑：AstaXie
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/1698
+GoCN归档: https://gocn.vip/topics/1698
 
 ## GoCN每日新闻(2018-03-20)
 
@@ -20,7 +20,7 @@ GoCN归档: https://gocn.io/question/1698
 
 编辑: 傅小黑
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/1702
+GoCN归档: https://gocn.vip/topics/1702
 
 
 ## GoCN每日新闻(2018-03-21)
@@ -34,7 +34,7 @@ GoCN归档: https://gocn.io/question/1702
 编辑: yulibaozi
 
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/1703
+GoCN归档: https://gocn.vip/topics/1703
 
 
 ## GoCN每日新闻(2018-03-22)
@@ -48,7 +48,7 @@ GoCN归档: https://gocn.io/question/1703
 编辑: 李森森
 
 订阅新闻:http://tinyletter.com/gocn
-GoCN归档:https://gocn.io/question/1706
+GoCN归档:https://gocn.vip/topics/1706
 
 ## GoCN每日新闻(2018-03-23)
 
@@ -60,7 +60,7 @@ GoCN归档:https://gocn.io/question/1706
 
 编辑:Razil
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/1712
+GoCN归档: https://gocn.vip/topics/1712
 
 # GoCN每日新闻(2018-03-24)
 
@@ -72,7 +72,7 @@ GoCN归档: https://gocn.io/question/1712
 
 编辑:马怀博
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/1717
+GoCN归档: https://gocn.vip/topics/1717
 
 
 # GoCN每日新闻(2018-03-25)
@@ -85,7 +85,7 @@ GoCN归档: https://gocn.io/question/1717
 
 编辑: lwhile
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/1720
+GoCN归档: https://gocn.vip/topics/1720
 
 
 

--- a/201803/20180326-20180401.md
+++ b/201803/20180326-20180401.md
@@ -8,7 +8,7 @@
 
 - 编辑: 宋佳洋  
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档: https://gocn.io/question/1723  
+- GoCN归档: https://gocn.vip/topics/1723  
 
 ## GoCN每日新闻(2018-03-27)
 
@@ -20,7 +20,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档:  https://gocn.io/question/1729
+- GoCN归档:  https://gocn.vip/topics/1729
 
 ## GoCN每日新闻(2018-03-28)
 
@@ -32,7 +32,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档:  https://gocn.io/question/1734
+- GoCN归档:  https://gocn.vip/topics/1734
 
 
 ## GoCN每日新闻(2018-03-29)
@@ -45,7 +45,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档:  https://gocn.io/question/1739
+- GoCN归档:  https://gocn.vip/topics/1739
 
 ## GoCN每日新闻(2018-03-30)
 
@@ -56,7 +56,7 @@
 5. Go 语法速览与实践清单 https://juejin.im/post/5abca7176fb9a028cd452c5a 
 
 - 编辑: samurai
-- GoCN归档: https://gocn.io/question/1740 
+- GoCN归档: https://gocn.vip/topics/1740 
 
 ## GoCN每日新闻(2018-03-31)
 
@@ -67,7 +67,7 @@
 5. QALM Uber的QoS 管理框架 https://eng.uber.com/qalm/ 
 
 - 编辑: asta
-- GoCN归档: https://gocn.io/question/1744 
+- GoCN归档: https://gocn.vip/topics/1744 
 
 
 ## GoCN每日新闻(2018-04-01)
@@ -82,4 +82,4 @@ Asta推荐每月一书：《有效学习》
 在终身学习的时代，如何有效学习与坚持学习一样重要。我们自己所习得的学习技巧，可能都不再适应当下的处境，尤其是在这样一个时间极度碎片化的时代，如何系统化学习，成为每个人必须解决的问题。https://book.douban.com/subject/28551589/
 
 - 编辑: 罗发宣
-- GoCN归档: https://gocn.io/question/1747
+- GoCN归档: https://gocn.vip/topics/1747

--- a/201804/20180402-20180408.md
+++ b/201804/20180402-20180408.md
@@ -9,7 +9,7 @@
 友情提醒：由于邮件列表服务商发送上限限制，邮件列表订阅接收目前存在问题，正在着手解决。
 
 * 编辑: 李俱顺Kevin 
-* GoCN归档: https://gocn.io/question/1749
+* GoCN归档: https://gocn.vip/topics/1749
 
 ## GoCN每日新闻(2018-04-03)
 
@@ -22,7 +22,7 @@
 友情提醒：由于邮件列表服务商发送上限限制，邮件列表订阅接收目前存在问题，正在着手解决。
 
 编辑: 傅小黑
-GoCN归档: https://gocn.io/question/1753
+GoCN归档: https://gocn.vip/topics/1753
 
 ## GoCN每日新闻(2018-04-04)
 
@@ -35,7 +35,7 @@ GoCN归档: https://gocn.io/question/1753
 友情提醒：由于邮件列表服务商发送上限限制，邮件列表订阅接收目前存在问题，正在着手解决。
 
 招聘信息：
-【北京】商汤科技招聘Go工程师 https://gocn.io/question/1629
+【北京】商汤科技招聘Go工程师 https://gocn.vip/topics/1629
 【杭州】阿里系统软件事业部Golang高级开发工程师 https://gocn.io/article/694
 
 编辑: yulibaozi
@@ -65,7 +65,7 @@ GoCN归档: https://gocn.io/publish/1756
 友情提醒：由于邮件列表服务商发送上限限制，邮件列表订阅接收目前存在问题，正在着手解决。
 
 * 编辑:Razil
-* GoCN归档: https://gocn.io/question/1762
+* GoCN归档: https://gocn.vip/topics/1762
 
 # GoCN每日新闻(2018-04-07)
 
@@ -79,7 +79,7 @@ GoCN归档: https://gocn.io/publish/1756
 
 * 编辑:马怀博
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/1762
+* GoCN归档: https://gocn.vip/topics/1762
 
 # GoCN每日新闻(2018-04-08)
 1.  使用Zipkin构建Go应用程序 https://medium.com/@jcchavezs/b79cc858ac3e
@@ -92,4 +92,4 @@ GoCN归档: https://gocn.io/publish/1756
 
 * 编辑: 卢炜豪
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.io/question/1771
+* GoCN归档：https://gocn.vip/topics/1771

--- a/201804/20180402-20180408.md
+++ b/201804/20180402-20180408.md
@@ -39,7 +39,7 @@ GoCN归档: https://gocn.vip/topics/1753
 【杭州】阿里系统软件事业部Golang高级开发工程师 https://gocn.io/article/694
 
 编辑: yulibaozi
-GoCN归档: https://gocn.io/publish/1756
+GoCN归档: https://gocn.vip/topics/1756
 
 ## GoCN每日新闻(2018-04-05)
 
@@ -52,7 +52,7 @@ GoCN归档: https://gocn.io/publish/1756
 友情提醒：由于邮件列表服务商发送上限限制，邮件列表订阅接收目前存在问题，正在着手解决。
 
 * 编辑: 李森森
-* GoCN归档: https://gocn.io/article/702
+* GoCN归档: https://gocn.vip/topics/8823
 
 ## GoCN每日新闻(2018-04-06)
 

--- a/201804/20180409-20180415.md
+++ b/201804/20180409-20180415.md
@@ -9,7 +9,7 @@
 友情提醒：由于邮件列表服务商发送上限限制，邮件列表订阅接收目前存在问题，正在着手解决。
 
 * 编辑: 宋佳洋
-* GoCN归档：https://gocn.io/question/1775
+* GoCN归档：https://gocn.vip/topics/1775
 
 
 ## GoCN每日新闻(2018-04-10)
@@ -21,7 +21,7 @@
 5. 区块链是社交App 的新机遇？  https://www.forbes.com/sites/ksamani/2018/04/09/opportunities-for-blockchain-based-social-apps/#6f1682262bd0
 
 * 编辑: 薛锦
-* GoCN归档:  https://gocn.io/question/1778
+* GoCN归档:  https://gocn.vip/topics/1778
 
 ## GoCN每日新闻(2018-04-11)
 
@@ -32,7 +32,7 @@
 5. 如何用区块链技术解决信任问题？http://mp.weixin.qq.com/s/737vmxtLu8daNtL6uM2QaQ
 
 * 编辑: 周云轩
-* GoCN归档:  https://gocn.io/question/1783
+* GoCN归档:  https://gocn.vip/topics/1783
 
 
 ## GoCN每日新闻(2018-04-12)
@@ -46,7 +46,7 @@
 活动信息：GopherChina 2018  04-14 ~ 04-15（上海）http://www.gopherchina.org/
 
 * 编辑: 崔广章
-* GoCN归档:  https://gocn.io/question/1788
+* GoCN归档:  https://gocn.vip/topics/1788
 
 
 ## GoCN每日新闻(2018-04-13)
@@ -60,7 +60,7 @@
 活动信息：GopherChina 2018  04-14 ~ 04-15（上海）http://www.gopherchina.org/
 
 * 编辑: 何小云
-* GoCN归档: https://gocn.io/question/1793 
+* GoCN归档: https://gocn.vip/topics/1793 
 
 ## GoCN每日新闻(2018-04-14)
 
@@ -71,7 +71,7 @@
 5. Nginx unit released版1.0发布（nginx动态web服务器，支持go语言）https://www.nginx.com/blog/nginx-unit-1-0-released
 
 * 编辑: samurai
-* GoCN归档: https://gocn.io/question/1796
+* GoCN归档: https://gocn.vip/topics/1796
 
 ## GoCN每日新闻(2018-04-15)
 
@@ -82,4 +82,4 @@
 5. 从先进走向普遍的广告和推荐系统方法之一: 在线学习 http://www.algorithmdog.com/advance-to-normal1
 
 * 编辑: 罗发宣
-* GoCN归档: https://gocn.io/question/1799
+* GoCN归档: https://gocn.vip/topics/1799

--- a/201804/20180416-20180422.md
+++ b/201804/20180416-20180422.md
@@ -10,7 +10,7 @@
 * 【上海】上海华为招聘devops、云计算研发工程师 https://gocn.io/article/718
 
 编辑: 李俱顺Kevin    
-GoCN归档: https://gocn.io/question/1801
+GoCN归档: https://gocn.vip/topics/1801
 
 
 ## GoCN每日新闻(2018-04-17)
@@ -22,10 +22,10 @@ GoCN归档: https://gocn.io/question/1801
 5. Docker容器可视化监控中心搭建 https://juejin.im/post/5ad52d3bf265da237840c0ec
 
 * GopherChina2018全部Slides https://github.com/gopherchina/conference/tree/master/2018
-* [上海徐汇] 积梦智能招聘Go工程师 https://gocn.io/question/1803
+* [上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/topics/1803
 
 * 编辑: 傅小黑
-GoCN归档: https://gocn.io/question/1806
+GoCN归档: https://gocn.vip/topics/1806
 
 
 ## GoCN每日新闻(2018-04-18)
@@ -37,11 +37,11 @@ GoCN归档: https://gocn.io/question/1806
 5. 微服务API网关 https://github.com/eolinker/GoKu-API-Gateway
 
 * GopherChina2018全部Slides https://github.com/gopherchina/conference/tree/master/2018
-* [上海徐汇] 积梦智能招聘Go工程师 https://gocn.io/question/1803
+* [上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/topics/1803
 * [上海]上海华为招聘devops、云计算研发工程师 https://gocn.io/article/718
 
 * 编辑: yulibaozi
-GoCN归档:https://gocn.io/question/1813
+GoCN归档:https://gocn.vip/topics/1813
 
 ## GoCN每日新闻(2018-04-19)
 
@@ -64,10 +64,10 @@ GoCN归档:https://gocn.io/article/728
 
 招聘信息: 
 1.【北京】【FreeWheel】Go后台开发 https://gocn.io/article/730   
-2.【深圳】【萌蛋】Go游戏开发 https://gocn.io/question/1818  
+2.【深圳】【萌蛋】Go游戏开发 https://gocn.vip/topics/1818  
 
 * 编辑:Razil
-* GoCN归档: https://gocn.io/question/1820
+* GoCN归档: https://gocn.vip/topics/1820
 
 ## GoCN每日新闻(2018-04-21)
 
@@ -78,11 +78,11 @@ GoCN归档:https://gocn.io/article/728
 5. 基于golang的爬虫实战 https://my.oschina.net/EIKPE2lvl3wigMQG/blog/1798447
 
 招聘信息:
-1.【上海徐汇】积梦智能招聘Go工程师 https://gocn.io/question/1803
-2.【深圳】【萌蛋】Go游戏开发 https://gocn.io/question/1818
+1.【上海徐汇】积梦智能招聘Go工程师 https://gocn.vip/topics/1803
+2.【深圳】【萌蛋】Go游戏开发 https://gocn.vip/topics/1818
 
 编辑: 马怀博
-GoCN归档: https://gocn.io/question/1824
+GoCN归档: https://gocn.vip/topics/1824
  
 ## GoCN每日新闻(2018-04-22)
 
@@ -93,9 +93,9 @@ GoCN归档: https://gocn.io/question/1824
 5. 时序数据库技术体系 – InfluxDB TSM存储引擎之数据写入  https://mp.weixin.qq.com/s/8oxknZqRbeLi4iUlC7lQtg
 
 招聘信息:
-1.【北京+深圳】商汤科技招聘Golang/Java/C++工程师  https://gocn.io/question/1822
+1.【北京+深圳】商汤科技招聘Golang/Java/C++工程师  https://gocn.vip/topics/1822
 2.【深圳】火币网深圳公司招聘Go高级开发工程师 https://gocn.io/article/726
 
 编辑: lwhile
-GoCN归档: https://gocn.io/question/1825
+GoCN归档: https://gocn.vip/topics/1825
  

--- a/201804/20180416-20180422.md
+++ b/201804/20180416-20180422.md
@@ -52,7 +52,7 @@ GoCN归档:https://gocn.vip/topics/1813
 5. 为什么你可以拥有数百万个Goroutines，但只有数千个Java线程 https://rcoh.me/posts/why-you-can-have-a-million-go-routines-but-only-1000-java-threads/
 
 * 编辑: 李森森
-GoCN归档:https://gocn.io/article/728
+GoCN归档:https://gocn.vip/topics/8846
 
 ## GoCN每日新闻(2018-04-20)
 

--- a/201804/20180423-20180429.md
+++ b/201804/20180423-20180429.md
@@ -7,7 +7,7 @@
 5. 京东首席架构师：618大促网关承载十亿调用量背后的架构实践 https://my.oschina.net/u/3772106/blog/1799394
 
 - 编辑: 宋佳洋  
-- GoCN归档: https://gocn.io/question/1827
+- GoCN归档: https://gocn.vip/topics/1827
 
 ## GoCN每日新闻(2018-04-24)
 
@@ -18,7 +18,7 @@
 5. Russ Cox: 谈谈 Go 的依赖以及未来  https://changelog.com/gotime/77
 
 - 编辑: 薛锦
-- GoCN归档: https://gocn.io/question/1835
+- GoCN归档: https://gocn.vip/topics/1835
 
 ## GoCN每日新闻(2018-04-25)
 
@@ -30,7 +30,7 @@
 5. 介绍kubeless的go function https://medium.com/bitnami-perspectives/introducing-golang-functions-to-kubeless-a9a9e4f0cab1
 
 - 编辑: 周云轩
-- GoCN归档: https://gocn.io/question/1836
+- GoCN归档: https://gocn.vip/topics/1836
 
 
 ## GoCN每日新闻(2018-04-26)
@@ -42,7 +42,7 @@
 5. go sync.Map源码分析 https://juejin.im/post/5ae01447f265da0ba062d2e8
 
 - 编辑: 崔广章
-- GoCN归档: https://gocn.io/question/1840
+- GoCN归档: https://gocn.vip/topics/1840
 
 
 
@@ -54,33 +54,33 @@
 4. 阿里妈妈基于TensorFlow做了哪些深度优化？TensorFlowRS架构解析 https://mp.weixin.qq.com/s/yuHavuGTYMH5JDC_1fnjcg 
 5. 基于人工智能场景的移动平台工程化实践 https://mp.weixin.qq.com/s/EtUlaslOUrmp9a2gQOJmnQ
 
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 - 编辑: 何小云
-- GoCN归档: https://gocn.io/question/1846
+- GoCN归档: https://gocn.vip/topics/1846
 
 ## GoCN每日新闻(2018-04-28)
 
-1. Golang中多大的对象算是大对象，多小的对象算是小对象？ https://gocn.io/question/1845
+1. Golang中多大的对象算是大对象，多小的对象算是小对象？ https://gocn.vip/topics/1845
 2. 爬虫带你了解一下Golang的市场行情 https://segmentfault.com/a/1190000014643720
 3. Go并发危害的思考 https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/
 4. 如何用mocks写出更好的单元测试 https://medium.com/@peter.gtz/how-to-write-better-unit-tests-in-go-using-mocks-4dd05e867b17
 5. 大型分布式网站架构实战项目分析 https://juejin.im/post/5ae1e71af265da0b7527d442
 
 * GopherChina 2018 视频上线(购票者免费) http://www.itdks.com/dakashuo/playback/2046
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 - 编辑: samurai
-- GoCN归档: https://gocn.io/question/1849
+- GoCN归档: https://gocn.vip/topics/1849
 
 ## GoCN每日新闻(2018-04-29)
 
 1. GCC8提供Go1.10.1用户包的完整实现 https://gcc.gnu.org/gcc-8/changes.html#go
-2. Go高性能分词Gsev0.10.0发布 https://gocn.io/question/1848
+2. Go高性能分词Gsev0.10.0发布 https://gocn.vip/topics/1848
 3. Go边界检查消除 https://www.ardanlabs.com/blog/2018/04/bounds-check-elimination-in-go.html
 4. 通过测试学习Go https://quii.gitbook.io/learn-go-with-tests/standard-lib-essentials/http-server
 5. WebSocket浅析 https://mp.weixin.qq.com/s/7aXMdnajINt0C5dcJy2USg
 
 * GopherChina 2018 视频上线(购票者免费) http://www.itdks.com/dakashuo/playback/2046
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 - 编辑: 罗发宣
-- GoCN归档: https://gocn.io/question/1853
+- GoCN归档: https://gocn.vip/topics/1853

--- a/201804/20180430-20180506.md
+++ b/201804/20180430-20180506.md
@@ -8,7 +8,7 @@ GoCN每日新闻(2018-04-30)
 5. fuzzy：Go实现的模糊匹配编辑器插件 https://github.com/sahilm/fuzzy
 
 * GopherChina 2018 视频上线(购票者免费) http://www.itdks.com/dakashuo/playback/2046
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 编辑: 李俱顺Kevin    
-GoCN归档: https://gocn.io/question/1855
+GoCN归档: https://gocn.vip/topics/1855

--- a/201805/20180501-20180507.md
+++ b/201805/20180501-20180507.md
@@ -7,24 +7,24 @@
 5. Goland  2018.1.2 发布 https://blog.jetbrains.com/go/2018/04/27/goland-2018-1-2-is-out/
 
 * GopherChina 2018 视频上线(购票者免费) http://www.itdks.com/dakashuo/playback/2046
-* Gopher Meetup 巡回第一站 - 深圳  https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳  https://gocn.vip/topics/1841
 
 编辑: 傅小黑
-GoCN归档: https://gocn.io/question/1861
+GoCN归档: https://gocn.vip/topics/1861
 
 ## GoCN每日新闻(2018-05-02)
 
 1. Go 1.10.2 and 1.9.6 发布 https://groups.google.com/forum/#!topic/golang-announce/
-2. 关于range的一个知识点 https://gocn.io/question/1862
+2. 关于range的一个知识点 https://gocn.vip/topics/1862
 3. 喜忧参半的 Kubernetes 生产之路 https://mp.weixin.qq.com/s/tM1BnnFGhLUuQZo_7ZeEiA
 4. 一个高性能的系统日志解析库 https://github.com/influxdata/go-syslog
 5. Kubernetes 状态管理与扩展 https://mp.weixin.qq.com/s/eHt61H1tAQsPmfSlrnMsjA
 
 - GopherChina 2018 视频上线(购票者免费) http://www.itdks.com/dakashuo/playback/2046
-- Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+- Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 编辑: yulibaozi
-GoCN归档: https://gocn.io/question/1863
+GoCN归档: https://gocn.vip/topics/1863
 
 ## GoCN每日新闻(2018-05-03)
 
@@ -35,10 +35,10 @@ GoCN归档: https://gocn.io/question/1863
 5. Google 发布gVisor容器沙箱 https://github.com/google/gvisor
 
 - GopherChina 2018 视频上线(购票者免费) http://www.itdks.com/dakashuo/playback/2046
-- Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+- Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 编辑: 李森森
-GoCN归档: https://gocn.io/question/1867
+GoCN归档: https://gocn.vip/topics/1867
 
 ## GoCN每日新闻(2018-05-04)
 
@@ -48,10 +48,10 @@ GoCN归档: https://gocn.io/question/1867
 4. API网关部署与版本管理 https://medium.com/devops-faith/deploying-and-versioning-an-api-gateway-42440a88986c
 5. corral:高性能轻量级MapReduce框架 https://github.com/bcongdon/corral
 
-* Gopher Meetup 巡回第一站 - 深圳  https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳  https://gocn.vip/topics/1841
 
 编辑:Razil
-GoCN归档: https://gocn.io/question/1870
+GoCN归档: https://gocn.vip/topics/1870
 
 ## GoCN每日新闻(2018-05-05)
 
@@ -61,10 +61,10 @@ GoCN归档: https://gocn.io/question/1870
 4. 悟空API网关 开源版 https://github.com/eolinker/GoKu-API-Gateway
 5. k8s与监控--改造telegraf的buffer实现 https://segmentfault.com/a/1190000014701582
 
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 编辑: 马怀博
-GoCN归档: https://gocn.io/question/1872
+GoCN归档: https://gocn.vip/topics/1872
 
 ## GoCN每日新闻(2018-05-06)
 
@@ -74,7 +74,7 @@ GoCN归档: https://gocn.io/question/1872
 4. HTTP Endpoint变化通知工具flare https://github.com/diegobernardes/flare
 5. Nginx也许并不是Service Mesh最好的选择,Envoy才是 https://www.servercoder.com/2018/03/27/envoy-grpc-not-nginx/
 
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 编辑: lwhile
-GoCN归档: https://gocn.io/question/1873
+GoCN归档: https://gocn.vip/topics/1873

--- a/201805/20180507-20180513.md
+++ b/201805/20180507-20180513.md
@@ -91,4 +91,4 @@ Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 5. 深入分析Kubernetes Scheduler的优先级队列 https://my.oschina.net/jxcdwangtao/blog/1811164
 
 - 编辑: 罗发宣
-- GoCN归档: https://gocn.vip/topics/
+- GoCN归档: https://gocn.vip/topics/1911

--- a/201805/20180507-20180513.md
+++ b/201805/20180507-20180513.md
@@ -6,10 +6,10 @@
 4. Gopher 新加坡大会视频 https://engineers.sg/organization/gopherconsg
 5. Heptio 开源的 k8s 负载均衡调度平台 https://github.com/heptio/gimbal
 
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 编辑: 宋佳洋   
-GoCN归档: https://gocn.io/question/1874
+GoCN归档: https://gocn.vip/topics/1874
 
 ## GoCN每日新闻(2018-05-08)
 
@@ -19,10 +19,10 @@ GoCN归档: https://gocn.io/question/1874
 4. 围绕 k8s 生态的创业公司逐步增多： https://techcrunch.com/2018/05/07/as-kubernetes-grows-a-startup-ecosystem-develops-in-its-wake/
 5. Go 五分钟教学系列： https://medium.com/go-in-5-minutes
 
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 - 编辑: 薛锦
-- GoCN归档:  https://gocn.io/question/1876
+- GoCN归档:  https://gocn.vip/topics/1876
 
 ## GoCN每日新闻(2018-05-09)
 
@@ -32,10 +32,10 @@ GoCN归档: https://gocn.io/question/1874
 4. 一文看尽Google I/O大会 https://mp.weixin.qq.com/s/bBUKbCIbufBPRhZdNDblOw
 5. 把可执行文件创建成macOS应用 https://github.com/machinebox/appify
 
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 - 编辑: 周云轩
-- GoCN归档:  https://gocn.io/question/1880
+- GoCN归档:  https://gocn.vip/topics/1880
 
 ## GoCN每日新闻(2018-05-10)
 
@@ -46,12 +46,12 @@ GoCN归档: https://gocn.io/question/1874
 5. 贝壳找房权限服务的探索和实践 https://mp.weixin.qq.com/s/xRKMvjEpS58kpikNTkbp1Q
 
 招聘信息:
-【深圳】大疆创新 招聘Golang研发工程师，运维架构师 (20-40k) https://gocn.io/question/1898
+【深圳】大疆创新 招聘Golang研发工程师，运维架构师 (20-40k) https://gocn.vip/topics/1898
 活动信息：
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 - 编辑: 崔广章
-- GoCN归档:  https://gocn.io/question/1900
+- GoCN归档:  https://gocn.vip/topics/1900
 
 ## GoCN每日新闻(2018-05-11)
 
@@ -62,11 +62,11 @@ GoCN归档: https://gocn.io/question/1874
 5. Go语言集成开发环境GoLand更新至2018.1.3版本 https://www.oschina.net/news/95967/goland-2018-1-3-released
 
 招聘信息: 
-【深圳】大疆创新 招聘Golang研发工程师，运维架构师 (20-40k) https://gocn.io/question/1898 活动信息：
-* Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+【深圳】大疆创新 招聘Golang研发工程师，运维架构师 (20-40k) https://gocn.vip/topics/1898 活动信息：
+* Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 - 编辑: 何小云
-- GoCN归档： https://gocn.io/question/1906
+- GoCN归档： https://gocn.vip/topics/1906
 
 ## GoCN每日新闻(2018-05-12)
 
@@ -76,11 +76,11 @@ GoCN归档: https://gocn.io/question/1874
 4. 深入分析Kubernetes Scheduler的优先级队列 https://my.oschina.net/jxcdwangtao/blog/1811164
 5. Github Go语言项目stars数排行榜 https://github.com/kaxap/arl/blob/master/README-Go.md
 
-招聘信息: 【杭州】同花顺招聘容器云golang开发 https://gocn.io/question/1909
-Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
+招聘信息: 【杭州】同花顺招聘容器云golang开发 https://gocn.vip/topics/1909
+Gopher Meetup 巡回第一站 - 深圳 https://gocn.vip/topics/1841
 
 - 编辑: samurai
-- GoCN归档： https://gocn.io/question/1910
+- GoCN归档： https://gocn.vip/topics/1910
 
 ## GoCN每日新闻(2018-05-13)
 
@@ -91,4 +91,4 @@ Gopher Meetup 巡回第一站 - 深圳 https://gocn.io/question/1841
 5. 深入分析Kubernetes Scheduler的优先级队列 https://my.oschina.net/jxcdwangtao/blog/1811164
 
 - 编辑: 罗发宣
-- GoCN归档: https://gocn.io/question/
+- GoCN归档: https://gocn.vip/topics/

--- a/201805/20180514-20180520.md
+++ b/201805/20180514-20180520.md
@@ -31,7 +31,7 @@
  - Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z8WTxO2xA
 
 编辑: yulibaozi
-GoCN归档: https://gocn.io/publish/1918
+GoCN归档: https://gocn.vip/topics/1918
 
 
 ## GoCN每日新闻(2018-05-17)
@@ -45,7 +45,7 @@ GoCN归档: https://gocn.io/publish/1918
 - Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z8WTxO2xA
 
 - 编辑: 李森森
-- GoCN归档: https://gocn.io/article/789
+- GoCN归档: https://gocn.vip/topics/8871
 
 ## GoCN每日新闻(2018-05-18)
 

--- a/201805/20180514-20180520.md
+++ b/201805/20180514-20180520.md
@@ -7,7 +7,7 @@
 5. Docker底层的内核知识——namespace https://mp.weixin.qq.com/s/YtS0mz5Cw7oTSP97h0V1uA
 
 - 编辑: 李俱顺Kevin
-- GoCN归档: https://gocn.io/question/1913
+- GoCN归档: https://gocn.vip/topics/1913
 
 ## GoCN每日新闻(2018-05-15)
 
@@ -18,11 +18,11 @@
 5. 容器环境下 go 服务性能诊断方案设计与实现 https://liudanking.com/arch/%E5%AE%B9%E5%99%A8%E7%8E%AF%E5%A2%83%E4%B8%8B-go-%E6%9C%8D%E5%8A%A1%E6%80%A7%E8%83%BD%E8%AF%8A%E6%96%AD%E6%96%B9%E6%A1%88%E8%AE%BE%E8%AE%A1%E4%B8%8E%E5%AE%9E%E7%8E%B0/
 
 - 编辑: 傅小黑
-- GoCN归档: https://gocn.io/question/1914
+- GoCN归档: https://gocn.vip/topics/1914
 
 ## GoCN每日新闻(2018-05-16)
 
-1. Go 夜读-源码阅读和开源技术分析 https://gocn.io/question/1695
+1. Go 夜读-源码阅读和开源技术分析 https://gocn.vip/topics/1695
 2. 在Docker VIRTUAL EVENT 上提出的7个问题 https://blog.docker.com/2018/05/windows-containers-in-dockeree-virtual-event/
 3. Go语言开发RESTFul JSON API https://segmentfault.com/a/1190000014875956
 4. 不理解Zookeeper一致性原理，谈何异地多活改造 https://mp.weixin.qq.com/s/4NtdY6nEBi173Ya4yHWy2g
@@ -81,5 +81,5 @@ GoCN归档: https://gocn.io/publish/1918
  - Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z8WTxO2xA
 
 编辑: lwhile
-归档: https://gocn.io/question/1928
+归档: https://gocn.vip/topics/1928
 

--- a/201805/20180521-20180527.md
+++ b/201805/20180521-20180527.md
@@ -9,7 +9,7 @@
 Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z8WTxO2xA
 
 - 编辑: 宋佳洋
-- 归档: https://gocn.io/question/1939
+- 归档: https://gocn.vip/topics/1939
 
 
 ## GoCN每日新闻(2018-05-22)
@@ -23,7 +23,7 @@ Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z
 * Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z8WTxO2xA
 
 - 编辑: 薛锦
-- GoCN归档:  https://gocn.io/question/1940
+- GoCN归档:  https://gocn.vip/topics/1940
 
 
 ## GoCN每日新闻(2018-05-23)
@@ -37,7 +37,7 @@ Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z
 * Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z8WTxO2xA
 
 - 编辑: 周云轩
-- GoCN归档:  https://gocn.io/question/1942
+- GoCN归档:  https://gocn.vip/topics/1942
 
 ## GoCN每日新闻(2018-05-24)
 
@@ -50,7 +50,7 @@ Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z
 * Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z8WTxO2xA
 
 编辑: 崔广章
-GoCN归档:  https://gocn.io/question/1944
+GoCN归档:  https://gocn.vip/topics/1944
 
 ## GoCN每日新闻(2018-05-25)
 1. 使用CQRS模式创建Golang微服务 https://outcrawl.com/go-microservices-cqrs-docker/
@@ -62,7 +62,7 @@ GoCN归档:  https://gocn.io/question/1944
 * Gopher Meetup 巡回第一站 - 深圳 https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z8WTxO2xA
 
 - 编辑: 何小云
-- GoCN归档： https://gocn.vip/question/1950
+- GoCN归档： https://gocn.vip/topics/1950
 
 ## GoCN每日新闻(2018-05-26)
 
@@ -74,7 +74,7 @@ GoCN归档:  https://gocn.io/question/1944
 
 * Gopher Meetup 巡回第一站 深圳（最后一天报名） https://mp.weixin.qq.com/s/YHBwMiVGO2Sk9z8WTxO2xA
 - 编辑: samurai 
-- GoCN归档：https://gocn.io/question/1952
+- GoCN归档：https://gocn.vip/topics/1952
 
 ## GoCN每日新闻(2018-05-27)
 
@@ -85,4 +85,4 @@ GoCN归档:  https://gocn.io/question/1944
 5. wasm添加支持native Go函数  https://www.reddit.com/r/golang/comments/8m8yl3/wasm_gointerpreterwagon_wasmmodules_with_native/
 
 编辑: 罗发宣
-GoCN归档: https://gocn.vip/question/1953
+GoCN归档: https://gocn.vip/topics/1953

--- a/201805/20180528-20180603.md
+++ b/201805/20180528-20180603.md
@@ -9,7 +9,7 @@
 * 提醒：https://gocn.io 因备案问题切换至 https://gocn.vip
 
 编辑: 李俱顺Kevin    
-GoCN归档: https://gocn.vip/question/1955
+GoCN归档: https://gocn.vip/topics/1955
 
 ##GoCN每日新闻(2018-05-29)
 
@@ -21,7 +21,7 @@ GoCN归档: https://gocn.vip/question/1955
 
 编辑: 傅小黑
 
-GoCN归档: https://gocn.vip/question/1959
+GoCN归档: https://gocn.vip/topics/1959
 
 ## GoCN每日新闻(2018-05-30)
 
@@ -33,7 +33,7 @@ GoCN归档: https://gocn.vip/question/1959
 
 编辑: yulibaozi
 
-GoCN归档: https://gocn.vip/question/1961
+GoCN归档: https://gocn.vip/topics/1961
 
 ## GoCN每日新闻(2018-05-31)
 
@@ -57,7 +57,7 @@ GoCN归档: https://gocn.vip/article/813
 5. NodeJs之父发布下一代基于Go和Typescript的Node-Deno https://github.com/ry/deno
 
 编辑:Razil
-GoCN归档: https://gocn.vip/question/1964
+GoCN归档: https://gocn.vip/topics/1964
 
 ## GoCN每日新闻(2018-06-02)
 
@@ -68,7 +68,7 @@ GoCN归档: https://gocn.vip/question/1964
 5. 以太坊开发SDK(离线签名) https://www.npmjs.com/package/ethereumjs-sdk
 
 编辑: 马怀博
-归档: https://gocn.vip/question/1967
+归档: https://gocn.vip/topics/1967
 
 ## GoCN每日新闻(2018-06-03)
 
@@ -79,4 +79,4 @@ GoCN归档: https://gocn.vip/question/1964
 5. 可观测的异常检查工作流 https://eng.uber.com/observability-anomaly-detection/
 
 编辑: lwhile
-归档: https://gocn.vip/question/1968
+归档: https://gocn.vip/topics/1968

--- a/201806/20180604-20180610.md
+++ b/201806/20180604-20180610.md
@@ -8,7 +8,7 @@ https://medium.com/@masroor.hasan.n/publishing-a-go-package-to-github-with-circl
 5. Go 和 CGO 跨平台编译之 armv7l https://medium.com/def-repr-self/cross-compiling-go-and-cgo-targeting-armv7l-musl-libc-f96c610834a8
 
 * 编辑: 宋佳洋   
-* 归档: https://gocn.vip/question/1969
+* 归档: https://gocn.vip/topics/1969
 
 
 ## GoCN每日新闻(2018-06-05)
@@ -21,7 +21,7 @@ https://medium.com/@masroor.hasan.n/publishing-a-go-package-to-github-with-circl
 
 
 * 编辑: 薛锦
-* GoCN归档:  https://gocn.vip/question/1970
+* GoCN归档:  https://gocn.vip/topics/1970
 
 ## GoCN每日新闻(2018-06-06)
 
@@ -33,7 +33,7 @@ https://medium.com/@masroor.hasan.n/publishing-a-go-package-to-github-with-circl
 
 
 * 编辑: 周云轩
-* GoCN归档:  https://gocn.vip/question/1973
+* GoCN归档:  https://gocn.vip/topics/1973
 
 ## GoCN每日新闻(2018-06-07)
 
@@ -46,7 +46,7 @@ https://medium.com/@masroor.hasan.n/publishing-a-go-package-to-github-with-circl
 GopherChina 2018 视频 youtube 发布 https://www.youtube.com/watch?v=w-mm9Oeny5o&list=PLx_Mc4dJcQbl3VCLLQFo-FrF_U4UN1s7b
 
 * 编辑: 崔广章
-* GoCN归档: https://gocn.vip/question/1977
+* GoCN归档: https://gocn.vip/topics/1977
 
 ## GoCN每日新闻(2018-06-08)
 
@@ -59,7 +59,7 @@ GopherChina 2018 视频 youtube 发布 https://www.youtube.com/watch?v=w-mm9Oeny
 GopherChina 2018 视频 youtube 发布 https://www.youtube.com/watch?v=w-mm9Oeny5o&list=PLx_Mc4dJcQbl3VCLLQFo-FrF_U4UN1s7b
 
 * 编辑: 何小云
-* GoCN归档: https://gocn.vip/question/1980
+* GoCN归档: https://gocn.vip/topics/1980
 
 ## GoCN每日新闻(2018-06-09)
 
@@ -72,7 +72,7 @@ GopherChina 2018 视频 youtube 发布 https://www.youtube.com/watch?v=w-mm9Oeny
 GopherChina 2018 视频 youtube 发布 https://www.youtube.com/watch?v=w-mm9Oeny5o&list=PLx_Mc4dJcQbl3VCLLQFo-FrF_U4UN1s7b
 
 * 编辑: samurai
-* GoCN归档: https://gocn.vip/question/1981
+* GoCN归档: https://gocn.vip/topics/1981
 
 ## GoCN每日新闻(2018-06-10)
 
@@ -83,4 +83,4 @@ GopherChina 2018 视频 youtube 发布 https://www.youtube.com/watch?v=w-mm9Oeny
 5. 推荐系统中的EE问题及基本Bandit算法 https://www.jianshu.com/p/95b2de50ce44
 
 * 编辑: 罗发宣
-* GoCN归档: https://gocn.vip/question/1983
+* GoCN归档: https://gocn.vip/topics/1983

--- a/201806/20180611-20180617.md
+++ b/201806/20180611-20180617.md
@@ -7,7 +7,7 @@
 5. fathom: 基于Go实现的访客分析系统 https://github.com/usefathom/fathom
 
 * 编辑: 李俱顺Kevin    
-* GoCN归档: https://gocn.vip/question/1984
+* GoCN归档: https://gocn.vip/topics/1984
 
 
 ## GoCN每日新闻(2018-06-12)
@@ -19,7 +19,7 @@
 5. Windows 的 Go 环境管理工具 rungo https://adamlamar.github.io/2018-06-11-rungo-on-windows/ 
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/1989
+* GoCN归档: https://gocn.vip/topics/1989
 
 ## GoCN每日新闻(2018-06-13)
 
@@ -31,7 +31,7 @@
 
 编辑: yulibaozi
 
-GoCN归档: https://gocn.vip/question/1991
+GoCN归档: https://gocn.vip/topics/1991
 
 ## GoCN每日新闻(2018-06-14)
 
@@ -43,7 +43,7 @@ GoCN归档: https://gocn.vip/question/1991
 
 编辑: 李森森
 
-GoCN归档: https://gocn.vip/question/1994
+GoCN归档: https://gocn.vip/topics/1994
 
 ## GoCN每日新闻(2018-06-16)
 
@@ -55,7 +55,7 @@ GoCN归档: https://gocn.vip/question/1994
 
 编辑: 马怀博
 
-归档: https://gocn.vip/question/1997
+归档: https://gocn.vip/topics/1997
 
 ## GoCN每日新闻(2018-06-17)
 
@@ -67,7 +67,7 @@ GoCN归档: https://gocn.vip/question/1994
 
 编辑: lwhile
 
-归档: https://gocn.vip/question/1998
+归档: https://gocn.vip/topics/1998
 
 
 

--- a/201806/20180618-20180624.md
+++ b/201806/20180618-20180624.md
@@ -1,13 +1,13 @@
 ## GoCN每日新闻(2018-06-18)
  
 1. SQS 消费者模式：高扩展的并发管理架构设计  https://medium.com/@questhenkart/sqs-consumer-design-achieving-high-scalability-while-managing-concurrency-in-go-d5a8504ea754
-2. Go 微服务实战汇总 https://gocn.vip/question/1999
+2. Go 微服务实战汇总 https://gocn.vip/topics/1999
 3. Go 系列文章4 : 调度器 http://xargin.com/go-scheduler
 4. 基于 nano 的游戏服务端开源示例 https://github.com/lonnng/nanoserver
 5. 使用 kubectl 访问 Kubernetes 集群时的身份验证和授权  https://tonybai.com/2018/06/14/the-authentication-and-authorization-of-kubectl-when-accessing-k8s-cluster/
 
 * 编辑: 宋佳洋  
-* 归档: https://gocn.vip/question/2002
+* 归档: https://gocn.vip/topics/2002
 
 ## GoCN每日新闻(2018-06-19)
 
@@ -19,7 +19,7 @@
 
 
 * 编辑: 薛锦
-* GoCN归档:  https://gocn.vip/question/2005
+* GoCN归档:  https://gocn.vip/topics/2005
 
 ## GoCN每日新闻(2018-06-20)
 
@@ -29,10 +29,10 @@
 4. 蚂蚁金服Service Mesh演进 https://mp.weixin.qq.com/s/jfRPsNPQRV7GVsk_glqMYA
 5. 十问 TiDB ：关于架构设计的一些思考 https://mp.weixin.qq.com/s/m2_Mf0-x_KpPHbnOawyy2A
 
-【活动】Gopher Meetup 巡回第一站 - 杭州 https://gocn.vip/question/2008
+【活动】Gopher Meetup 巡回第一站 - 杭州 https://gocn.vip/topics/2008
 
 * 编辑: 周云轩
-* GoCN归档:  https://gocn.vip/question/2007
+* GoCN归档:  https://gocn.vip/topics/2007
 
 
 ## GoCN每日新闻(2018-06-21)
@@ -43,10 +43,10 @@
 4. Netflix的容器管理平台Titus开源了 https://mp.weixin.qq.com/s/5jxeuh7pwtAGBYwlTo-nSQ
 5. 响应式微服务架构-分布式系统设计原则 https://mp.weixin.qq.com/s/Bftf_DXy1ZHqNugGql1u-A
 
-【活动】Gopher Meetup 巡回第二站 - 杭州 https://gocn.vip/question/2008
+【活动】Gopher Meetup 巡回第二站 - 杭州 https://gocn.vip/topics/2008
 
 编辑: 崔广章
-GoCN归档:  https://gocn.vip/question/2012
+GoCN归档:  https://gocn.vip/topics/2012
 
 
 ## GoCN每日新闻(2018-06-22)
@@ -57,10 +57,10 @@ GoCN归档:  https://gocn.vip/question/2012
 4. Kubernetes RBAC 详细使用方法 https://blog.qikqiak.com/post/use-rbac-in-k8s/
 5. TiDB 源码阅读系列文章（十）Chunk 和执行框架简介 https://cloud.tencent.com/developer/article/1148491
 
-【活动】Gopher Meetup 巡回第二站 - 杭州 https://gocn.vip/question/2008
+【活动】Gopher Meetup 巡回第二站 - 杭州 https://gocn.vip/topics/2008
 
 编辑: 何小云
-GoCN归档: https://gocn.vip/question/2015
+GoCN归档: https://gocn.vip/topics/2015
 
 
 ## GoCN每日新闻(2018-06-23)
@@ -71,10 +71,10 @@ GoCN归档: https://gocn.vip/question/2015
 4. Go 微服务：基于 RabbitMQ 和 AMQP 进行消息传递 https://juejin.im/post/5b2c82446fb9a00e3642635f
 5. Go实现的git协议解析器 https://github.com/google/gitprotocolio
 
-【活动】Gopher Meetup 巡回第二站 - 杭州 https://gocn.vip/question/2008
+【活动】Gopher Meetup 巡回第二站 - 杭州 https://gocn.vip/topics/2008
 
 * 编辑: samurai
-* GoCN归档：https://gocn.vip/question/2017
+* GoCN归档：https://gocn.vip/topics/2017
 
 ## GoCN每日新闻(2018-06-24)
 
@@ -84,7 +84,7 @@ GoCN归档: https://gocn.vip/question/2015
 4. WASM与Go:前景一览 https://brianketelsen.com/web-assembly-and-go-a-look-to-the-future/
 5. 浅显易懂的分布式TensorFlow入门教程 https://mp.weixin.qq.com/s/mibROQsKrBCQDmXxT2sCGQ
 
-*【活动】Gopher Meetup 巡回第二站 - 杭州 https://gocn.vip/question/2008
+*【活动】Gopher Meetup 巡回第二站 - 杭州 https://gocn.vip/topics/2008
 
 * 编辑: 罗发宣
-* GoCN归档：https://gocn.vip/question/2018
+* GoCN归档：https://gocn.vip/topics/2018

--- a/201806/20180625-20180701.md
+++ b/201806/20180625-20180701.md
@@ -6,10 +6,10 @@
 4. 使用Golang+HTML构建桌面应用 https://www.mchampaneri.in/2018/06/sciter-gui-application-with-golang.html
 5. Fuse在I/O测试中的应用 https://medium.com/@siddontang/use-fuse-to-inject-failure-to-i-o-deb5f2e7800a 
 
-*【活动】Gopher Meetup 巡回第二站 - 杭州 https://gocn.vip/question/2008
+*【活动】Gopher Meetup 巡回第二站 - 杭州 https://gocn.vip/topics/2008
 
 * 编辑: 李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2022
+* GoCN归档：https://gocn.vip/topics/2022
 
 ## GoCN每日新闻(2018-06-26)
 
@@ -20,7 +20,7 @@
 5. Go 绘制 ASCII 曲线 https://github.com/guptarohit/asciigraph
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/2023
+* GoCN归档: https://gocn.vip/topics/2023
 
 ## GoCN每日新闻(2018-06-27)
 
@@ -31,7 +31,7 @@
 5. Meq：构建你的消息推送、聊天及IoT服务 http://meq.io/
 
 编辑: yulibaozi
-GoCN归档: https://gocn.vip/question/2025
+GoCN归档: https://gocn.vip/topics/2025
 
 ## GoCN每日新闻(2018-06-28)
 
@@ -53,7 +53,7 @@ GoCN归档: https://gocn.vip/article/853
 5. jstream:流式Json解析库 https://github.com/bcicen/jstream
 
 * 编辑:Razil
-* GoCN归档:https://gocn.vip/question/2026
+* GoCN归档:https://gocn.vip/topics/2026
 
 ## GoCN每日新闻(2018-06-30)
 
@@ -64,7 +64,7 @@ GoCN归档: https://gocn.vip/article/853
 5. kurun: 执行k8s命令工具 https://banzaicloud.github.io/blog/kurun/
 
 * 编辑: 马怀博
-* GoCN归档: https://gocn.vip/question/2028
+* GoCN归档: https://gocn.vip/topics/2028
 
 ## GoCN每日新闻(2018-07-01)
 
@@ -75,5 +75,5 @@ GoCN归档: https://gocn.vip/article/853
 5. 为docker容器配置日志rotation https://medium.freecodecamp.org/how-to-setup-log-rotation-for-a-docker-container-a508093912b2
 
 编辑: lwhile
-归档: https://gocn.vip/question/2030
+归档: https://gocn.vip/topics/2030
 

--- a/201807/20180702-20180708.md
+++ b/201807/20180702-20180708.md
@@ -8,7 +8,7 @@
 
 
 * 编辑: 宋佳洋
-* 归档: https://gocn.vip/question/2032
+* 归档: https://gocn.vip/topics/2032
 
 ## GoCN每日新闻(2018-07-03)
 
@@ -20,7 +20,7 @@
 
 
 * 编辑: 薛锦
-* GoCN归档:  https://gocn.vip/question/2034
+* GoCN归档:  https://gocn.vip/topics/2034
 
 ## GoCN每日新闻(2018-07-04)
 
@@ -34,7 +34,7 @@
 * 【成都】【创乐汇】招聘go https://gocn.vip/article/863
 
 * 编辑: 周云轩
-* GoCN归档:  https://gocn.vip/question/2036
+* GoCN归档:  https://gocn.vip/topics/2036
 
 ## GoCN每日新闻(2018-07-05)
 
@@ -45,7 +45,7 @@
 5. 2018年后端开发人员技术学习指南 https://medium.com/tech-tajawal/modern-backend-developer-in-2018-6b3f7b5f8b9
 
 * 编辑：Samurai
-* GoCN归档：https://gocn.vip/question/2037
+* GoCN归档：https://gocn.vip/topics/2037
 
 
 ## GoCN每日新闻(2018-07-06)
@@ -57,7 +57,7 @@
 5. 以太坊又一次大拥堵何去何从？深度对话美图以太坊DPoS算法实现团队 https://mp.weixin.qq.com/s/QpHW5TCKJLT2fiMtADZh9A
 
 * 编辑：何小云
-* GoCN归档：https://gocn.vip/question/2039
+* GoCN归档：https://gocn.vip/topics/2039
 
 
 
@@ -70,7 +70,7 @@
 5. 一个可快速落地的微服务网关架构实现 https://mp.weixin.qq.com/s/FxEH82B7d9y762SI5DSBpA
 
 * 编辑：崔广章
-* GoCN归档：https://gocn.vip/question/2043
+* GoCN归档：https://gocn.vip/topics/2043
 
 
 ## GoCN每日新闻(2018-07-08) 
@@ -82,4 +82,4 @@
 5. DDOS防御:如何在一秒钟丢掉1000w的数据包 https://blog.cloudflare.com/how-to-drop-10-million-packets/
 
 * 编辑: 罗发宣
-* GoCN归档：https://gocn.vip/question/884
+* GoCN归档：https://gocn.vip/topics/884

--- a/201807/20180709-20180715.md
+++ b/201807/20180709-20180715.md
@@ -7,7 +7,7 @@
 5. gaia: 跨语言pipeline系统 https://github.com/gaia-pipeline/gaia
 
 * 编辑: 李俱顺Kevin    
-* GoCN归档：https://gocn.vip/question/2047
+* GoCN归档：https://gocn.vip/topics/2047
 
 ## GoCN每日新闻(2018-07-10)
 
@@ -18,7 +18,7 @@
 5.  网易工业级WebRTC应用实践深度解析  https://mp.weixin.qq.com/s/ytr7QLTVsEuTNnsYljsiKw
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/2048
+* GoCN归档: https://gocn.vip/topics/2048
 
 ## GoCN每日新闻(2018-07-11)
 
@@ -29,7 +29,7 @@
 5. 使用Go实现的去中心化P2P网络协议 https://medium.com/perlin-network/noise-an-opinionated-p2p-networking-stack-for-decentralized-protocols-in-go-bfc6fecf157d
 
 * 编辑: yulibaozi
-* GoCN归档: https://gocn.vip/question/2052
+* GoCN归档: https://gocn.vip/topics/2052
 
 
 ## GoCN每日新闻(2018-07-12)
@@ -41,7 +41,7 @@
 5. 使用Golang，chi和MySQL构建RESTful Web API服务 https://medium.com/@shaonshaonty/building-restful-web-api-service-using-golang-chi-mysql-d85f427dee54
 
 * 编辑: 李森森
-* GoCN归档:  https://gocn.vip/question/2054
+* GoCN归档:  https://gocn.vip/topics/2054
 
 ## GoCN每日新闻(2018-07-13)
 
@@ -52,7 +52,7 @@
 5. hop:更易使用的AMQP客户端包 https://github.com/mazingstudio/hop
 
 * 编辑:Razil
-* GoCN归档: https://gocn.vip/question/2055
+* GoCN归档: https://gocn.vip/topics/2055
 
 
 ## GoCN每日新闻(2018-07-14)
@@ -75,4 +75,4 @@
 
 编辑: lwhile
 
-GoCN归档: https://gocn.vip/question/2058
+GoCN归档: https://gocn.vip/topics/2058

--- a/201807/20180716-20180722.md
+++ b/201807/20180716-20180722.md
@@ -7,7 +7,7 @@
 5. Golang 实现的 Service Mesh 数据平面代理  https://github.com/alipay/sofa-mosn
 
 * 编辑: 宋佳洋
-* 归档: https://gocn.vip/question/2060
+* 归档: https://gocn.vip/topics/2060
 
 ## GoCN每日新闻(2018-07-17)
 
@@ -19,7 +19,7 @@
 
 
 * 编辑: 薛锦
-* GoCN归档:  https://gocn.vip/question/2063
+* GoCN归档:  https://gocn.vip/topics/2063
 
 ## GoCN每日新闻(2018-07-18)
 
@@ -31,7 +31,7 @@
 
 
 * 编辑: 周云轩
-* GoCN归档:  https://gocn.vip/question/2065
+* GoCN归档:  https://gocn.vip/topics/2065
 
 ## GoCN每日新闻(2018-07-19)
 
@@ -44,7 +44,7 @@
 【活动】Gopher Meetup 巡回第三站 - 北京站 https://www.bagevent.com/event/2018gophermeetupBJ
 
 * 编辑: 崔广章
-* GoCN归档: https://gocn.vip/question/2067
+* GoCN归档: https://gocn.vip/topics/2067
 
 ## GoCN每日新闻(2018-07-20)
 
@@ -57,7 +57,7 @@
 【活动】Gopher Meetup 巡回第三站 - 北京站 https://www.bagevent.com/event/2018gophermeetupBJ
 
 * 编辑: 何小云
-* GoCN归档: https://gocn.vip/question/2073
+* GoCN归档: https://gocn.vip/topics/2073
 
 ## GoCN每日新闻(2018-07-21)
 
@@ -70,7 +70,7 @@
 美帝Google Go team招人 https://go-jobs-at-goog.firebaseapp.com/
 
 * 编辑: samurai
-* GoCN归档: https://gocn.vip/question/2075
+* GoCN归档: https://gocn.vip/topics/2075
 
 
 ## GoCN每日新闻(2018-07-22) 
@@ -84,4 +84,4 @@
 * 活动: Gopher Meetup 北京站 https://www.bagevent.com/event/2018gophermeetupBJ
 
 * 编辑: 罗发宣
-* GoCN归档：https://gocn.vip/question/2076
+* GoCN归档：https://gocn.vip/topics/2076

--- a/201807/20180723-20180729.md
+++ b/201807/20180723-20180729.md
@@ -1,6 +1,6 @@
 ## GoCN每日新闻(2018-07-23)
 
-1. beego 1.10.0发布，修复大量已知问题 https://gocn.vip/question/2078
+1. beego 1.10.0发布，修复大量已知问题 https://gocn.vip/topics/2078
 2. GraphQL与Golang的结合实践 https://www.slideshare.net/appleboy/graphql-ingo-106518012
 3. 新功能Go modules介绍 https://systemdump.io/posts/2018-07-22-go-modules
 4. 构建K8s operator系列教程 https://itnext.io/building-an-operator-for-kubernetes-with-the-sample-controller-b4204be9ad56
@@ -9,7 +9,7 @@
 * 活动: Gopher Meetup 北京站 https://www.bagevent.com/event/2018gophermeetupBJ
 
 * 编辑: 李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2079
+* GoCN归档：https://gocn.vip/topics/2079
 
 
 ## GoCN每日新闻(2018-07-24)
@@ -21,7 +21,7 @@
 5. Google首款小程序「猜画小歌」用了哪些AI相关技术？ https://jizhi.im/blog/post/google_ai_chxg
 
 * 编辑: 傅小黑
-* GoCN归档：https://gocn.vip/question/2083
+* GoCN归档：https://gocn.vip/topics/2083
 
 ## GoCN每日新闻(2018-07-25)
 
@@ -32,7 +32,7 @@
 5. 如何理解日志系统 https://mp.weixin.qq.com/s/pv5w8Jnz4kTda8IuXkK2IA
 
 * 编辑: yulibaozi
-* GoCN归档：https://gocn.vip/question/2085
+* GoCN归档：https://gocn.vip/topics/2085
 
 ## GoCN每日新闻(2018-07-26)
 
@@ -43,7 +43,7 @@
 5. GitHub集成到你的Kubernetes集群的持续交付　https://github.com/manifoldco/heighliner
 
 * 编辑: 李森森
-* GoCN归档: https://gocn.vip/question/2086
+* GoCN归档: https://gocn.vip/topics/2086
 
 ## GoCN每日新闻(2018-07-27)
 
@@ -54,7 +54,7 @@
 5. astroflow-go: 一款轻量高效的日志包 https://github.com/astroflow/astroflow-go
 
 * 编辑:Razil
-* GoCN归档:https://gocn.vip/question/2091
+* GoCN归档:https://gocn.vip/topics/2091
 
 ## GoCN每日新闻(2018-07-28)
 
@@ -65,7 +65,7 @@
 5. 微服务简介 https://segmentfault.com/a/1190000015798054
 
 * 编辑: 马怀博
-* GoCN归档: https://gocn.vip/question/2093
+* GoCN归档: https://gocn.vip/topics/2093
 
 ## GoCN每日新闻(2018-07-29)
 
@@ -76,4 +76,4 @@
 5. 让事件飞 — Linux eventfd 原理与实践 https://zhuanlan.zhihu.com/p/40572954
 
 编辑: lwhile
-GoCN归档:  https://gocn.vip/question/2094
+GoCN归档:  https://gocn.vip/topics/2094

--- a/201807/20180730-20180805.md
+++ b/201807/20180730-20180805.md
@@ -7,7 +7,7 @@
 5. justforfunc 直播: 开始用 Go 使用 Tensorflow https://www.youtube.com/watch?v=skJitN1vZG0
 
 * 编辑: 宋佳洋
-* 归档: https://gocn.vip/question/2095
+* 归档: https://gocn.vip/topics/2095
 
 ## GoCN每日新闻(2018-07-31)
 
@@ -19,7 +19,7 @@
 
 
 * 编辑: 薛锦
-* GoCN归档:  https://gocn.vip/question/2101
+* GoCN归档:  https://gocn.vip/topics/2101
 
 ## GoCN每日新闻(2018-08-01)
 
@@ -31,8 +31,8 @@
 
 招聘信息：
 
-【上海】七牛云（商业运营）招聘golang开发工程师 https://gocn.vip/question/2087  
+【上海】七牛云（商业运营）招聘golang开发工程师 https://gocn.vip/topics/2087  
 【广州】蚂蚁金服中间件团队诚招Go https://gocn.vip/article/922
 
 * 编辑: 周云轩
-* GoCN归档:  https://gocn.vip/question/2105
+* GoCN归档:  https://gocn.vip/topics/2105

--- a/201808/20180802-20180805.md
+++ b/201808/20180802-20180805.md
@@ -8,11 +8,11 @@
 5. Redis 深度历险：核心原理与应用实践 https://mp.weixin.qq.com/s/6CXehn80jtz4GYkjACDeyQ
 
 * 招聘信息:
-  【上海】七牛云（商业运营）招聘golang开发工程师 https://gocn.vip/question/2087  
+  【上海】七牛云（商业运营）招聘golang开发工程师 https://gocn.vip/topics/2087  
   【广州】蚂蚁金服中间件团队诚招Go https://gocn.vip/article/922
 
 * 编辑: 崔广章
-* GoCN归档: https://gocn.vip/question/2108
+* GoCN归档: https://gocn.vip/topics/2108
 
 ## GoCN每日新闻(2018-08-03)
 
@@ -26,7 +26,7 @@
 【北京】快乐迭代 区块链项目 招聘 Go 开发工程师~ https://gocn.vip/article/927 【上海-新天地】e成诚募go语言架构师及开发工程师 https://gocn.vip/article/925
 
 * 编辑: 何小云
-* GoCN归档： https://gocn.vip/question/2112
+* GoCN归档： https://gocn.vip/topics/2112
 
 ## GoCN每日新闻(2018-08-04)
 
@@ -37,7 +37,7 @@
 5. Go 1.11 Beta 3 发布 http://t.cn/Res4ZeN
 
 * 编辑: samurai
-* GoCN: https://gocn.vip/question/2115
+* GoCN: https://gocn.vip/topics/2115
 
 
 ## GoCN每日新闻(2018-08-05) 
@@ -49,4 +49,4 @@
 5. 腾讯安全《2018上半年区块链安全报告》 https://slab.qq.com/news/authority/1754.html
 
 * 编辑: 罗发宣
-* GoCN归档：https://gocn.vip/question/2117
+* GoCN归档：https://gocn.vip/topics/2117

--- a/201808/20180806-20180812.md
+++ b/201808/20180806-20180812.md
@@ -8,7 +8,7 @@ GoCN每日新闻(2018-08-06)
 5. 基于 GitLab 的 CI 实践 https://mp.weixin.qq.com/s/ZzJnZtZn3sX-JmPfs1uASg
 
 * 编辑: 李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2118
+* GoCN归档：https://gocn.vip/topics/2118
 
 ## GoCN每日新闻(2018-08-07)
 
@@ -19,7 +19,7 @@ GoCN每日新闻(2018-08-06)
 5. 为什么 Containerum 使用 Go https://medium.com/containerum/why-we-use-go-to-develop-containerum-platform-for-kubernetes-3a33d5bdc5ec
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/2120
+* GoCN归档: https://gocn.vip/topics/2120
 
 
 ## GoCN每日新闻(2018-08-08)
@@ -31,7 +31,7 @@ GoCN每日新闻(2018-08-06)
 5. 使用Vagrant在本地一键部署3节点的K8s分布式集群和Istio Service Mesh https://github.com/rootsongjc/kubernetes-vagrant-centos-cluster
 
 * 编辑: yulibaozi
-* GoCN归档: https://gocn.vip/question/2125
+* GoCN归档: https://gocn.vip/topics/2125
 
 
 ## GoCN每日新闻(2018-08-09)
@@ -44,7 +44,7 @@ GoCN每日新闻(2018-08-06)
 
 
 * 编辑: 李森森
-* GoCN归档: https://gocn.vip/question/2129
+* GoCN归档: https://gocn.vip/topics/2129
 
 ## GoCN每日新闻(2018-08-10)
 
@@ -55,7 +55,7 @@ GoCN每日新闻(2018-08-06)
 5. GoFasion:一个轻量级的具备链式调用风格的JSON数据解析库 https://github.com/Anderson-Lu/gofasion
 
 * 编辑:Razil
-* GoCN归档: https://gocn.vip/question/2131
+* GoCN归档: https://gocn.vip/topics/2131
 
 ## GoCN每日新闻(2018-08-11)
 
@@ -77,5 +77,5 @@ GoCN每日新闻(2018-08-06)
 5. 你不理解你的软件工程师  https://medium.com/@amandoabreu/you-dont-understand-your-software-engineers-53442ca0805a
 
 编辑: lwhile
-GoCN归档: https://gocn.vip/question/2133
+GoCN归档: https://gocn.vip/topics/2133
 

--- a/201808/20180813-20180819.md
+++ b/201808/20180813-20180819.md
@@ -7,7 +7,7 @@
 5. 用 Go 编写的 Markdown slide 工具 https://github.com/bketelsen/slides
 
 * 编辑: 宋佳洋
-* GoCN归档: https://gocn.vip/question/2134
+* GoCN归档: https://gocn.vip/topics/2134
 
 ## GoCN每日新闻(2018-08-14)
 
@@ -18,7 +18,7 @@
 5. 持续集成（CI）入门： https://medium.com/@gwright_60924/continuous-integration-ci-e81032bb8502
 
 * 编辑: 薛锦
-* GoCN归档:  https://gocn.vip/question/2135
+* GoCN归档:  https://gocn.vip/topics/2135
 
 ## GoCN每日新闻(2018-08-15)
 
@@ -31,7 +31,7 @@
 Go11rc1发布 https://golang.org/dl/#go1.11rc1
 
 * 编辑: 周云轩
-* GoCN归档:  https://gocn.vip/question/2137
+* GoCN归档:  https://gocn.vip/topics/2137
 
 ## GoCN每日新闻(2018-08-16)
 
@@ -43,7 +43,7 @@ Go11rc1发布 https://golang.org/dl/#go1.11rc1
 
 
 * 编辑: 崔广章
-* GoCN归档: https://gocn.vip/question/2138
+* GoCN归档: https://gocn.vip/topics/2138
 
 
 ## GoCN每日新闻(2018-08-17)
@@ -56,7 +56,7 @@ Go11rc1发布 https://golang.org/dl/#go1.11rc1
 
 
 * 编辑: 何小云
-* GoCN归档: https://gocn.vip/question/2140
+* GoCN归档: https://gocn.vip/topics/2140
 
 
 ## GoCN每日新闻(2018-08-18)
@@ -69,7 +69,7 @@ Go11rc1发布 https://golang.org/dl/#go1.11rc1
 5. Go 2设计我最喜欢的3个修改提议 https://dev.to/deanveloper/my-favorite-go-2-proposals-3lie
 
 * 编辑：samurai
-* GoCN归档：https://gocn.vip/question/2141
+* GoCN归档：https://gocn.vip/topics/2141
 
 ## GoCN每日新闻(2018-08-19)
 
@@ -80,4 +80,4 @@ Go11rc1发布 https://golang.org/dl/#go1.11rc1
 5. 推荐30个用于微服务的顶级工具 https://mp.weixin.qq.com/s/XmlmN2h7cCguJc6spBoD7w
 
 * 编辑: 罗发宣
-* GoCN归档：https://gocn.vip/question/2142
+* GoCN归档：https://gocn.vip/topics/2142

--- a/201808/20180820-20180826.md
+++ b/201808/20180820-20180826.md
@@ -7,7 +7,7 @@
 5. Wag: Go实现的wasm编译器 https://github.com/tsavola/wag
 
 * 编辑：李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2143
+* GoCN归档：https://gocn.vip/topics/2143
 
 ## GoCN每日新闻(2018-08-21)
 
@@ -18,7 +18,7 @@
 5. 微服务的数据一致性解决方案 https://juejin.im/post/5b7a5a7f518825430d26ae7d
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/2146
+* GoCN归档: https://gocn.vip/topics/2146
 
 
 ## GoCN每日新闻(2018-08-22)
@@ -30,7 +30,7 @@
 5. water 一个简单好用的TUN/TAP库 https://github.com/songgao/water
 
 * 编辑: yulibaozi
-* GoCN归档:https://gocn.vip/question/2149
+* GoCN归档:https://gocn.vip/topics/2149
 
 ## GoCN每日新闻(2018-08-23)
 
@@ -41,7 +41,7 @@
 5. 解析术语密码学 http://www.golangprograms.com/cryptography/what-is-cryptography.html
 
 * 编辑: 李森森
-* GoCN归档: https://gocn.vip/question/2153
+* GoCN归档: https://gocn.vip/topics/2153
 
 ## GoCN每日新闻(2018-08-24)
 
@@ -52,7 +52,7 @@
 5. dsched:一款分布式任务调度器 https://gitlab.com/andreynech/dsched
 
 * 编辑:Razil
-* GoCN归档: https://gocn.vip/question/2158
+* GoCN归档: https://gocn.vip/topics/2158
 
 ## GoCN每日新闻(2018-08-25)
 
@@ -74,4 +74,4 @@
 
 编辑: lwhile
 
-GoCN归档: https://gocn.vip/question/2165
+GoCN归档: https://gocn.vip/topics/2165

--- a/201808/20180827-20180902.md
+++ b/201808/20180827-20180902.md
@@ -8,7 +8,7 @@
 
 
 * 编辑: 薛锦
-* GoCN归档:  https://gocn.vip/question/2167
+* GoCN归档:  https://gocn.vip/topics/2167
 
 
 ## GoCN每日新闻(2018-08-28)
@@ -21,7 +21,7 @@
 
 
 * 编辑: 薛锦
-* GoCN归档:  https://gocn.vip/question/2168
+* GoCN归档:  https://gocn.vip/topics/2168
 
 ## GoCN每日新闻(2018-08-29)
 
@@ -32,11 +32,11 @@
 5. InnoDB巧妙实现4种事务的隔离级别 https://mp.weixin.qq.com/s/x_7E2R2i27Ci5O7kLQF0UA
 
 招聘信息：<br>
-[上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/question/1803<br>
-[上海北京] 今日头条招聘Go工程师 https://gocn.vip/question/2170<br>
+[上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/topics/1803<br>
+[上海北京] 今日头条招聘Go工程师 https://gocn.vip/topics/2170<br>
 
 * 编辑: 周云轩
-* GoCN归档:  https://gocn.vip/question/2171
+* GoCN归档:  https://gocn.vip/topics/2171
 
 
 ## GoCN每日新闻(2018-08-30)
@@ -48,11 +48,11 @@
 5. 基于SDN的多址边缘计算系统 https://mp.weixin.qq.com/s/1FEMPfXsjGWU_Wrh9O1Whg
 
 招聘信息：<br>
-[上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/question/1803<br>
-[上海北京] 今日头条招聘Go工程师 https://gocn.vip/question/2170<br>
+[上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/topics/1803<br>
+[上海北京] 今日头条招聘Go工程师 https://gocn.vip/topics/2170<br>
 
 * 编辑: 崔广章
-* GoCN归档: https://gocn.vip/question/2174
+* GoCN归档: https://gocn.vip/topics/2174
 
 
 ## GoCN每日新闻(2018-08-31)
@@ -63,11 +63,11 @@
 5. 玩转Go module代理 https://roberto.selbach.ca/go-proxies/
 
 招聘信息：<br>
-[上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/question/1803<br>
-[上海北京] 今日头条招聘Go工程师 https://gocn.vip/question/2170<br>
+[上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/topics/1803<br>
+[上海北京] 今日头条招聘Go工程师 https://gocn.vip/topics/2170<br>
 
 * 编辑: 何小云
-* GoCN归档: https://gocn.vip/question/2176
+* GoCN归档: https://gocn.vip/topics/2176
 
 
 ## GoCN每日新闻(2018-09-01)
@@ -79,7 +79,7 @@
 5. 使用Istio实现一个Service Mesh以简化微服务间的通信模式 模式 https://mp.weixin.qq.com/s/5YSRgZtJBDr5LLVpBT7QJw
 
 * 编辑：samurai
-* GoCN归档：归档：https://gocn.vip/question/2177
+* GoCN归档：归档：https://gocn.vip/topics/2177
 
 ## GoCN每日新闻(2018-09-02)
 1. gobox中的consumer处理框架 http://blog.7rule.com/2018/09/01/gobox-consumer.html
@@ -89,4 +89,4 @@
 5. GopherCon UK 2018 https://www.youtube.com/playlist?list=PLDWZ5uzn69ewsMyuGjVsAnpQIjyud1Cv9
 
 * 编辑: 罗发宣
-* GoCN归档：https://gocn.vip/question/2178
+* GoCN归档：https://gocn.vip/topics/2178

--- a/201809/20180903-20180909.md
+++ b/201809/20180903-20180909.md
@@ -7,7 +7,7 @@
 5. [观点]Go2.0泛型讨论 https://emilymaier.net/words/getting-specific-about-generics/
 
 * 编辑：李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2182
+* GoCN归档：https://gocn.vip/topics/2182
 
 
 ## GoCN每日新闻(2018-09-04)
@@ -21,7 +21,7 @@
 * 阿里集团招聘容器调度技术专家（25K-40K）https://gocn.vip/article/966
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/2183
+* GoCN归档: https://gocn.vip/topics/2183
 
 ## GoCN每日新闻(2018-09-05)
 
@@ -36,7 +36,7 @@
 - [北京] Matrix区块链公司招聘Go工程师（15K-30K） https://gocn.vip/article/954
 
 编辑: yulibaozi
-GoCN归档: https://gocn.vip/question/2184
+GoCN归档: https://gocn.vip/topics/2184
 
 ## GoCN每日新闻(2018-09-06)
 
@@ -47,7 +47,7 @@ GoCN归档: https://gocn.vip/question/2184
 5. GopherCon 2018 - 在Go中实现网络协议 https://about.sourcegraph.com/go/gophercon-2018-implementing-a-network-protocol-in-go/
 
 * 编辑: 李森森
-* GoCN归档: https://gocn.vip/question/2189
+* GoCN归档: https://gocn.vip/topics/2189
 
 ## GoCN每日新闻(2018-09-07)
 
@@ -58,7 +58,7 @@ GoCN归档: https://gocn.vip/question/2184
 5. migrate:数据库迁移库与命令行工具 https://github.com/golang-migrate/migrate
 
 * 编辑:Razil
-* GoCN归档:  https://gocn.vip/question/2192
+* GoCN归档:  https://gocn.vip/topics/2192
 
 ## GoCN每日新闻(2018-09-08)
 
@@ -69,7 +69,7 @@ GoCN归档: https://gocn.vip/question/2184
 5. Golang基于Gitlab CI/CD部署方案 http://www.chairis.cn/blog/article/96
 
 * 编辑: 马怀博
-* GoCN归档: https://gocn.vip/question/2194
+* GoCN归档: https://gocn.vip/topics/2194
 
 ## GoCN每日新闻(2018-09-09)
 
@@ -80,4 +80,4 @@ GoCN归档: https://gocn.vip/question/2184
 5. 论开源项目的可持续发展 https://medium.com/@mattklein123/the-broken-economics-of-oss-5a1b31fc0182
 
 * 编辑: lwhile
-* GoCN归档: https://gocn.vip/question/2196
+* GoCN归档: https://gocn.vip/topics/2196

--- a/201809/20180910-20180916.md
+++ b/201809/20180910-20180916.md
@@ -7,7 +7,7 @@
 5. Flannel 网络以及在阿里云下的实现解析 http://ylzheng.com/2018/09/07/k8s-flannel-in-alicloud
 
 - 编辑: 宋佳洋 
-- GoCN归档:  https://gocn.vip/question/2198
+- GoCN归档:  https://gocn.vip/topics/2198
 
 ## GoCN每日新闻(2018-09-11)
 
@@ -19,7 +19,7 @@
 
 
 - 编辑: 薛锦
-- GoCN归档:  https://gocn.vip/question/2199
+- GoCN归档:  https://gocn.vip/topics/2199
 
 ## GoCN每日新闻(2018-09-12)
 
@@ -30,7 +30,7 @@
 5. 从人肉到智能，阿里运维体系经历了哪些变迁？ https://mp.weixin.qq.com/s/gsW-AtNWT_0LLvTMX0lD0w
 
 - 编辑: 周云轩
-- GoCN归档:  :  https://gocn.vip/question/2202
+- GoCN归档:  :  https://gocn.vip/topics/2202
 
 ## GoCN每日新闻(2018-09-13)
 
@@ -41,10 +41,10 @@
 5. Docker容器实现原理及容器隔离性踩坑介绍  https://mp.weixin.qq.com/s/xN-UuURHz7Vyj3ItEvQ95g
 
 招聘信息
-- [上海] [七牛云]招聘前端/后端开发工程师（坐标浦东新区）https://gocn.vip/question/2203
+- [上海] [七牛云]招聘前端/后端开发工程师（坐标浦东新区）https://gocn.vip/topics/2203
 
 - 编辑: 崔广章
-- GoCN归档: https://gocn.vip/question/2205
+- GoCN归档: https://gocn.vip/topics/2205
 
 ## GoCN每日新闻(2018-09-15)
 
@@ -55,7 +55,7 @@
 5. 腾讯高性能RPC框架Tars Go实现版 现版 https://github.com/TarsCloud/TarsGo
 
 - 编辑：samurai
-- GoCN归档：归档：https://gocn.vip/question/2212
+- GoCN归档：归档：https://gocn.vip/topics/2212
 
 ## GoCN每日新闻(2018-09-16)
 
@@ -66,5 +66,5 @@
 5. HHVM_3.30：结束PHP支持和Hack的未来 https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html
 
 - 编辑: 罗发宣
-- GoCN归档：https://gocn.vip/question/2213
+- GoCN归档：https://gocn.vip/topics/2213
 

--- a/201809/20180917-20180923.md
+++ b/201809/20180917-20180923.md
@@ -7,7 +7,7 @@
 5. Golang 大杀器之性能剖析 PProf https://github.com/EDDYCJY/blog/blob/master/golang/2018-09-15-Golang%20%E5%A4%A7%E6%9D%80%E5%99%A8%E4%B9%8B%E6%80%A7%E8%83%BD%E5%89%96%E6%9E%90%20PProf.md
 
 * 编辑: 李俱顺Kevin
-* GoCN归档: https://gocn.vip/question/2214
+* GoCN归档: https://gocn.vip/topics/2214
 
 
 ## GoCN每日新闻(2018-09-18)
@@ -19,7 +19,7 @@
 5. Go vs Python http://govspy.peterbe.com/
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/2216
+* GoCN归档: https://gocn.vip/topics/2216
 
 
 ## GoCN每日新闻(2018-09-19)
@@ -31,7 +31,7 @@
 5. 如何在循环中使用代码创建goroutine https://www.reddit.com/r/golang/comments/9gsqdi/how_to_create_goroutines_with_tickers_in_a_loop/
 
 * 编辑: 李森森
-* GoCN归档: https://gocn.vip/question/2217
+* GoCN归档: https://gocn.vip/topics/2217
 
 
 ## GoCN每日新闻(2018-09-20)
@@ -43,7 +43,7 @@
 5. 桔子网关—全新企业级的API网关 https://github.com/mafanr/juz
 
 * 编辑: yulibaozi
-* GoCN归档: https://gocn.vip/question/2222
+* GoCN归档: https://gocn.vip/topics/2222
 
 ## GoCN每日新闻(2018-09-21)
 
@@ -54,7 +54,7 @@
 5. go-tsne: 一款Go语言实现的tSNE算法库 https://github.com/danaugrs/go-tsne
 
 * 编辑:Razil
-* GoCN归档: https://gocn.vip/question/2224
+* GoCN归档: https://gocn.vip/topics/2224
 
 ## GoCN每日新闻(2018-09-22)
 
@@ -76,5 +76,5 @@
 5. detective:分布式的应用运行健康状态监控库 https://github.com/sohamkamani/detective 
 
 * 编辑:Razil  
-* GoCN归档: https://gocn.vip/question/2230   
+* GoCN归档: https://gocn.vip/topics/2230   
 

--- a/201809/20180924-20180930.md
+++ b/201809/20180924-20180930.md
@@ -9,7 +9,7 @@ GoCN小组祝大家中秋节快乐
 5. 分享一个 docker/docker-compose DNS 帮助库 https://github.com/Oppodelldog/docker-dns
 
 * 编辑: 宋佳洋
-* GoCN归档: https://gocn.vip/question/2233
+* GoCN归档: https://gocn.vip/topics/2233
 
 ## GoCN每日新闻(2018-09-25)
 
@@ -23,7 +23,7 @@ GoCN小组祝大家中秋节快乐
 * Gopher Meetup 第四站上海站：  https://www.bagevent.com/event/shgopher
 
 * 编辑: 薛锦
-* GoCN归档:  https://gocn.vip/question/2235
+* GoCN归档:  https://gocn.vip/topics/2235
 
 ## GoCN每日新闻(2018-09-26)
 
@@ -36,7 +36,7 @@ GoCN小组祝大家中秋节快乐
 * Gopher Meetup 第四站上海站：  https://www.bagevent.com/event/shgopher
 
 * 编辑: 周云轩
-* GoCN归档:  https://gocn.vip/question/2239
+* GoCN归档:  https://gocn.vip/topics/2239
 
 ## GoCN每日新闻(2018-09-27)
 
@@ -50,7 +50,7 @@ GoCN小组祝大家中秋节快乐
 Gopher Meetup 第四站上海站：  https://www.bagevent.com/event/shgopher
 
 * 编辑: 崔广章
-* GoCN归档: https://gocn.vip/question/2245
+* GoCN归档: https://gocn.vip/topics/2245
 
 ## GoCN每日新闻(2018-09-28)
 
@@ -63,7 +63,7 @@ Gopher Meetup 第四站上海站：  https://www.bagevent.com/event/shgopher
 Gopher Meetup 第四站上海站：  https://www.bagevent.com/event/shgopher
 
 * 编辑: 何小云
-* GoCN归档: https://gocn.vip/question/2248
+* GoCN归档: https://gocn.vip/topics/2248
 
 ## GoCN每日新闻(2018-09-29)
 
@@ -74,10 +74,10 @@ Gopher Meetup 第四站上海站：  https://www.bagevent.com/event/shgopher
 5. Go pprof文件网页端在线转换UI火焰图 https://medium.com/@sathishvj/flamegraphs-for-code-optimization-with-golang-and-speedscope-80c20725fdd2
 
 * Gopher Meetup 第四站上海站：  https://www.bagevent.com/event/shgopher
-* VMware招聘云原生开发工程师 （北京）：https://gocn.vip/question/2246
+* VMware招聘云原生开发工程师 （北京）：https://gocn.vip/topics/2246
 
 * 编辑: samurai
-* GoCN归档: https://gocn.vip/question/2249
+* GoCN归档: https://gocn.vip/topics/2249
 
 ## GoCN每日新闻(2018-09-30)
 
@@ -90,4 +90,4 @@ Gopher Meetup 第四站上海站：  https://www.bagevent.com/event/shgopher
 * Gopher Meetup 第四站上海站：  https://www.bagevent.com/event/shgopher
 
 * 编辑: asta
-* GoCN归档: https://gocn.vip/question/2253
+* GoCN归档: https://gocn.vip/topics/2253

--- a/201810/20181001-20181007.md
+++ b/201810/20181001-20181007.md
@@ -11,7 +11,7 @@
 * Gopher Meetup 第四站上海站：  https://www.bagevent.com/event/shgopher
 
 * 编辑: 李俱顺Kevin    
-* GoCN归档: https://gocn.vip/question/2255
+* GoCN归档: https://gocn.vip/topics/2255
 
 
 ## GoCN每日新闻(2018-10-02)
@@ -23,7 +23,7 @@
 5. Go 1.11 Modules 初体验 https://medium.com/@KevinHoffman/my-first-exposure-to-go-1-11s-modules-ba85e238f5f5
 
 * 编辑: 傅小黑
-* GoCN归档:https://gocn.vip/question/2257
+* GoCN归档:https://gocn.vip/topics/2257
 
 
 ## GoCN每日新闻(2018-10-03)
@@ -35,7 +35,7 @@
 5. sourcegraph开源了 https://github.com/sourcegraph/sourcegraph
 
 * 编辑: yulibaozi
-* GoCN归档: https://gocn.vip/question/2258
+* GoCN归档: https://gocn.vip/topics/2258
 
 
 ## GoCN每日新闻(2018-10-04)
@@ -47,7 +47,7 @@
 5. 在个人的项目中使用Kubernetes http://www.doxsey.net/blog/kubernetes--the-surprisingly-affordable-platform-for-personal-projects
 
 * 编辑: 李森森
-* GoCN归档: https://gocn.vip/question/2260
+* GoCN归档: https://gocn.vip/topics/2260
 
 
 ## GoCN每日新闻(2018-10-05)
@@ -59,7 +59,7 @@
 5. 内存顺序 https://zhuanlan.zhihu.com/p/45566448
 
 * 编辑: lwhile
-* GoCN归档: https://gocn.vip/question/2261
+* GoCN归档: https://gocn.vip/topics/2261
 
 
 ## GoCN每日新闻(2018-10-06)
@@ -71,7 +71,7 @@
 5. 类型嵌入 https://go101.org/article/type-embedding.html
 
 * 编辑: 马怀博
-* GoCN归档: https://gocn.vip/question/2263
+* GoCN归档: https://gocn.vip/topics/2263
 
 ## GoCN每日新闻(2018-10-07)
 
@@ -82,4 +82,4 @@
 5. 浅析数据库并发控制机制 http://catkang.github.io/2018/09/19/concurrency-control.html
 
 * 编辑: lwhile
-* GoCN归档: https://gocn.vip/question/2264
+* GoCN归档: https://gocn.vip/topics/2264

--- a/201810/20181008-20181014.md
+++ b/201810/20181008-20181014.md
@@ -8,7 +8,7 @@
 
 
 - 编辑: 薛锦
-- GoCN归档:  https://gocn.vip/question/2266
+- GoCN归档:  https://gocn.vip/topics/2266
 
 
 ## GoCN每日新闻(2018-10-09)
@@ -22,7 +22,7 @@
 Gopher Meetup 第四站上海站： https://www.bagevent.com/event/shgopher
 
 - 编辑: 宋佳洋
-- GoCN归档: https://gocn.vip/question/2269
+- GoCN归档: https://gocn.vip/topics/2269
 
 ## GoCN每日新闻(2018-10-10)
 
@@ -35,7 +35,7 @@ Gopher Meetup 第四站上海站： https://www.bagevent.com/event/shgopher
 Gopher Meetup 第四站上海站： https://www.bagevent.com/event/shgopher
 
 - 编辑: 周云轩
-- GoCN归档: https://gocn.vip/question/2274
+- GoCN归档: https://gocn.vip/topics/2274
 
 
 ## GoCN每日新闻(2018-10-11)
@@ -63,7 +63,7 @@ Gopher Meetup 第四站上海站： https://www.bagevent.com/event/shgopher
 Gopher Meetup 第四站上海站： https://www.bagevent.com/event/shgopher
 
 - 编辑: 何小云
-- GoCN归档: https://gocn.vip/question/2276
+- GoCN归档: https://gocn.vip/topics/2276
 
 ## GoCN每日新闻(2018-10-13)
 
@@ -76,7 +76,7 @@ Gopher Meetup 第四站上海站： https://www.bagevent.com/event/shgopher
 Gopher Meetup 第四站上海站： 站： https://www.bagevent.com/event/shgopher
 
 - 编辑：samurai
-- GoCN归档：https://gocn.vip/question/2278
+- GoCN归档：https://gocn.vip/topics/2278
 
 ## GoCN每日新闻(2018-10-14)
 
@@ -89,4 +89,4 @@ Gopher Meetup 第四站上海站： 站： https://www.bagevent.com/event/shgoph
 Gopher Meetup 第四站上海站：https://www.bagevent.com/event/shgopher
 
 - 编辑: 罗发宣
-- GoCN归档：https://gocn.vip/question/2279
+- GoCN归档：https://gocn.vip/topics/2279

--- a/201810/20181015-20181021.md
+++ b/201810/20181015-20181021.md
@@ -9,7 +9,7 @@
 * Gopher Meetup 第四站上海站：https://www.bagevent.com/event/shgopher
 
 * 编辑: 李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2282
+* GoCN归档：https://gocn.vip/topics/2282
 
 ## GoCN每日新闻(2018-10-16)
 
@@ -20,7 +20,7 @@
 5. [视频] Go 如何布局项目结构 https://www.youtube.com/watch?v=B5oQnECDJ8g&t=
 
 编辑: 傅小黑
-GoCN归档: https://gocn.vip/question/2283
+GoCN归档: https://gocn.vip/topics/2283
 
 ## GoCN每日新闻(2018-10-17)
 
@@ -31,7 +31,7 @@ GoCN归档: https://gocn.vip/question/2283
 5. Go语言性能优化-两数之和算法性能研究 https://juejin.im/post/5bc68b8cf265da0ae92a9b46
 
 编辑: yulibaozi
-GoCN归档: https://gocn.vip/question/2289
+GoCN归档: https://gocn.vip/topics/2289
 
 
 ## GoCN每日新闻(2018-10-18)
@@ -43,7 +43,7 @@ GoCN归档: https://gocn.vip/question/2289
 5. 关于Golang包的所有信息 https://medium.com/rungo/everything-you-need-to-know-about-packages-in-go-b8bac62b74cc
 
 编辑: 李森森
-GoCN归档: https://gocn.vip/question/2290
+GoCN归档: https://gocn.vip/topics/2290
 
 ## GoCN每日新闻(2018-10-19)
 
@@ -54,7 +54,7 @@ GoCN归档: https://gocn.vip/question/2290
 5. sha256-simd:高速sha256计算库 https://github.com/minio/sha256-simd
 
 * 编辑:Razil
-* 归档:https://gocn.vip/question/2292
+* 归档:https://gocn.vip/topics/2292
 
 GoCN每日新闻(2018-10-20)
 
@@ -65,7 +65,7 @@ GoCN每日新闻(2018-10-20)
 5. 可组合的GIF效应CLI https://github.com/sgreben/yeetgif
 
 编辑:马怀博 
-GoCN归档 https://gocn.vip/question/2295
+GoCN归档 https://gocn.vip/topics/2295
 
 GoCN每日新闻(2018-10-21)
 
@@ -76,4 +76,4 @@ GoCN每日新闻(2018-10-21)
 5. 关键路径驱动开发 https://medium.com/@rakyll/cpdd-critical-path-driven-development-6c2592fb8ea4
 
 编辑: lwhile
-GoCN归档:  https://gocn.vip/question/2296
+GoCN归档:  https://gocn.vip/topics/2296

--- a/201810/20181022-20181028.md
+++ b/201810/20181022-20181028.md
@@ -7,7 +7,7 @@
 5. 分享一个图片转 ASCII 的工具 https://github.com/qeesung/image2ascii
 
 - 编辑: 宋佳洋  
-- GoCN归档: https://gocn.vip/question/2298
+- GoCN归档: https://gocn.vip/topics/2298
 
 
 ## GoCN每日新闻(2018-10-23)
@@ -19,7 +19,7 @@
 5. 通过 k8s 和 Istio 管理微服务：https://medium.com/kreuzwerker-gmbh/managing-microservices-with-kubernetes-and-istio-76efea547b28
 
 - 编辑: 薛锦
-- GoCN归档:  https://gocn.vip/question/2301
+- GoCN归档:  https://gocn.vip/topics/2301
 
 
 ## GoCN每日新闻(2018-10-24)
@@ -31,7 +31,7 @@
 5. go内外部包之争 https://medium.com/@vthallam/the-myth-about-golang-frameworks-and-external-libraries-93cb4b7da50f
 
 - 编辑: 周云轩
-- GoCN归档:  https://gocn.vip/question/2303
+- GoCN归档:  https://gocn.vip/topics/2303
 
 
 ## GoCN每日新闻(2018-10-25)
@@ -43,7 +43,7 @@
 5. Multi-Cloud Kubernetes 最佳实践 https://mp.weixin.qq.com/s/eG4AoXVGaXpMQJNFtj9sDg
 
 - 编辑: 崔广章
-- GoCN归档:  https://gocn.vip/question/2306
+- GoCN归档:  https://gocn.vip/topics/2306
 
 
 ## GoCN每日新闻(2018-10-26)
@@ -56,7 +56,7 @@
 
 
 - 编辑: 何小云
-- GoCN归档: https://gocn.vip/question/2327
+- GoCN归档: https://gocn.vip/topics/2327
 
 ## GoCN每日新闻(2018-10-27)
 
@@ -67,7 +67,7 @@
 5 Go开发工具GoLand新版本支持Mozilla rr调试和一些别的更强大的功能 https://blog.jetbrains.com/go/2018/10/25/goland-2018-3-eap-4-is-here/
 
 - 编辑：samurai
-- GoCN归档：https://gocn.vip/question/2329
+- GoCN归档：https://gocn.vip/topics/2329
 
 ## GoCN每日新闻(2018-10-28)
 
@@ -79,6 +79,6 @@
   http://blueskykong.com/2018/10/24/hash-bitmap/
 
 - 编辑: 罗发宣
-- GoCN归档：https://gocn.vip/question/2331
+- GoCN归档：https://gocn.vip/topics/2331
 
 

--- a/201810/20181029-20181104.md
+++ b/201810/20181029-20181104.md
@@ -7,7 +7,7 @@
 5. Golang反射深入理解 https://www.jianshu.com/p/1cf328cfe82b
 
 * 编辑: 李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2332
+* GoCN归档：https://gocn.vip/topics/2332
 
 
 ## GoCN每日新闻(2018-10-31)
@@ -23,7 +23,7 @@
 * 【广州/成都】iH5招聘Go工程师 https://gocn.vip/article/1022
 
 编辑: yulibaozi
-GoCN归档: https://gocn.vip/question/2337
+GoCN归档: https://gocn.vip/topics/2337
 
 
 ## GoCN每日新闻(2018-11-01)
@@ -36,7 +36,7 @@ GoCN归档: https://gocn.vip/question/2337
 
 * 招聘: https://gocn.vip/article/1013
 * 编辑: 李森森
-* GoCN归档：https://gocn.vip/question/2338
+* GoCN归档：https://gocn.vip/topics/2338
 
 ## GoCN每日新闻(2018-11-02)
 
@@ -50,7 +50,7 @@ GoCN归档: https://gocn.vip/question/2337
 * [上海]趣头条招聘Go开发工程师(20-40K) https://gocn.vip/article/1021
 
 * 编辑:Razil
-* GoCN归档: https://gocn.vip/question/2339 
+* GoCN归档: https://gocn.vip/topics/2339 
 
 ## GoCN每日新闻(2018-11-04)
 
@@ -61,4 +61,4 @@ GoCN归档: https://gocn.vip/question/2337
 5. 带有中间件的超高性能 API 网关 krakend  https://github.com/devopsfaith/krakend
 
 - 编辑: lwhile
-- GoCN归档:  https://gocn.vip/question/2343
+- GoCN归档:  https://gocn.vip/topics/2343

--- a/201811/20181105-20181111.md
+++ b/201811/20181105-20181111.md
@@ -7,7 +7,7 @@
 5. 可减少修复 I/O 开销的纠删码类库 https://github.com/templexxx/xrs
 
 - 编辑: 宋佳洋 
-- GoCN归档: https://gocn.vip/question/2345
+- GoCN归档: https://gocn.vip/topics/2345
 
 
 ## GoCN每日新闻(2018-11-06)
@@ -19,7 +19,7 @@
 5. 使用 IPFS 安全地共享区块链上的文件：https://medium.com/@mycoralhealth/learn-to-securely-share-files-on-the-blockchain-with-ipfs-219ee47df54c
 
 - 编辑: 薛锦
-- GoCN归档:  https://gocn.vip/question/2349
+- GoCN归档:  https://gocn.vip/topics/2349
 
 
 ## GoCN每日新闻(2018-11-07)
@@ -31,7 +31,7 @@
 5. 如何给女朋友解释什么是并发和并行 https://mp.weixin.qq.com/s/dfAKnpeLKPymULL7vRSYUA
 
 - 编辑: 周云轩
-- GoCN归档:  https://gocn.vip/question/2351
+- GoCN归档:  https://gocn.vip/topics/2351
 
 
 ## GoCN每日新闻(2018-11-08)
@@ -43,7 +43,7 @@
 5. Kubernetes何时才会消于无形却又无处不在？ https://mp.weixin.qq.com/s/80_uryVtlHnIFlgZDPy2Kw
 
 - 编辑: 崔广章
-- GoCN归档:  https://gocn.vip/question/2358
+- GoCN归档:  https://gocn.vip/topics/2358
 
 
 ## GoCN每日新闻(2018-11-09)
@@ -55,7 +55,7 @@
 5. 参加2018年Go用户调查 https://blog.golang.org/survey2018
 
 - 编辑: 何小云
-- GoCN归档: https://gocn.vip/question/2360
+- GoCN归档: https://gocn.vip/topics/2360
 
 ## GoCN每日新闻(2018-11-10)
 
@@ -68,7 +68,7 @@
 神马！！！大咖云集的 Gopher China 2019大会地点由我定？https://mp.weixin.qq.com/s/_MwxI5TLcav0GDRyS7T2ag
 
 - 编辑：samurai
-- GoCN归档：https://gocn.vip/question/2362
+- GoCN归档：https://gocn.vip/topics/2362
 
 ## GoCN每日新闻(2018-11-11)
 1. Go的九年历程 https://blog.golang.org/9years
@@ -78,4 +78,4 @@
 5. 浅谈大型互联网的企业入侵检测及防护策略 https://mp.weixin.qq.com/s/1Iry620hCkJ8sHA626T3Dg
 
 - 编辑: 罗发宣
-- GoCN归档：https://gocn.vip/question/2363
+- GoCN归档：https://gocn.vip/topics/2363

--- a/201811/20181112-20181118.md
+++ b/201811/20181112-20181118.md
@@ -7,7 +7,7 @@
 5. litfs：Go实现的FUSE文件系统 https://github.com/anaskhan96/litfs 
 
 * 编辑: 李俱顺
-* GoCN归档：https://gocn.vip/question/2364
+* GoCN归档：https://gocn.vip/topics/2364
 
 
 ## GoCN每日新闻(2018-11-13)
@@ -19,7 +19,7 @@
 5.  serverless框架,可伸缩部署你的应用到AWS: https://github.com/apex/up
 
 * 编辑: yulibaozi
-* GoCN归档：https://gocn.vip/question/2368
+* GoCN归档：https://gocn.vip/topics/2368
 
 ## GoCN每日新闻(2018-11-14)
 
@@ -30,7 +30,7 @@
 5. Golang 中实现禁止拷贝 https://jiajunhuang.com/articles/2018_11_12-golang_nocopy.md.html
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/2370
+* GoCN归档: https://gocn.vip/topics/2370
 
 ## GoCN每日新闻(2018-11-15)
 
@@ -41,7 +41,7 @@
 5. 悉尼Golang Meetup Go2草案规范 https://www.youtube.com/watch?feature=youtu.be&v=RIvL2ONhFBI
 
 * 编辑: 李森森
-* GoCN归档：https://gocn.vip/question/2373
+* GoCN归档：https://gocn.vip/topics/2373
 
 ## GoCN每日新闻(2018-11-16)
 
@@ -52,7 +52,7 @@
 5.beku:三行代码发布你的应用到K8s https://github.com/yulibaozi/beku  
  
 编辑: Razil
-归档: https://gocn.vip/question/2381
+归档: https://gocn.vip/topics/2381
 
 ## GoCN每日新闻(2018-11-17)
 
@@ -74,4 +74,4 @@
 5. 重构的时机和原因 https://medium.com/@audi17.2/refactoring-when-and-why-b5262ae92fcb
 
 编辑:lwhile
-归档: https://gocn.vip/question/2386
+归档: https://gocn.vip/topics/2386

--- a/201811/20181119-20181125.md
+++ b/201811/20181119-20181125.md
@@ -7,7 +7,7 @@
 5. 一个列出和查找许可证的 Go 类库 https://github.com/mitchellh/go-spdx
 
 - 编辑: 宋佳洋
-- 归档: https://gocn.vip/question/2388
+- 归档: https://gocn.vip/topics/2388
 
 ## GoCN每日新闻(2018-11-20)
 
@@ -18,7 +18,7 @@
 5. HTTP/3 学习笔记：https://blog.erratasec.com/2018/11/some-notes-about-http3.html#.W_NkHpMzbUI
 
 - 编辑: 薛锦
-- GoCN归档:  https://gocn.vip/question/2390
+- GoCN归档:  https://gocn.vip/topics/2390
 
 ## GoCN每日新闻(2018-11-21)
 
@@ -28,10 +28,10 @@
 4. Tcl和Raft发明人的软件设计哲学 https://mp.weixin.qq.com/s/l_xnOd2gmTSbj3WqZAL7aQ
 5. 进阶的Redis之数据持久化RDB与AOF https://mp.weixin.qq.com/s/BrgGxVDPR08Wd8TVVpYQkw
 
-* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/question/2391
+* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/topics/2391
 
 - 编辑: 周云轩
-- GoCN归档:  https://gocn.vip/question/2392
+- GoCN归档:  https://gocn.vip/topics/2392
 
 
 ## GoCN每日新闻(2018-11-22)
@@ -42,10 +42,10 @@
 4. Go 内置库第一季：net/url  https://juejin.im/post/5bf42ac0f265da61616e50b9
 5. 美团容器平台架构及容器技术实践 https://mp.weixin.qq.com/s/FGMkNexqKvFXmOTjqJZkfA
 
-* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/question/2391
+* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/topics/2391
 
 - 编辑: 崔广章
-- GoCN归档:  https://gocn.vip/question/2395
+- GoCN归档:  https://gocn.vip/topics/2395
 
 
 ## GoCN每日新闻(2018-11-23)
@@ -57,10 +57,10 @@
 5. 阿里如何做到百万量级硬件故障自愈？ https://mp.weixin.qq.com/s/G6qgI37RHzANpl2fyRUg0Q
 
 
-* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/question/2391
+* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/topics/2391
 
 - 编辑: 何小云
-- GoCN归档: https://gocn.vip/question/2398
+- GoCN归档: https://gocn.vip/topics/2398
 
 ## GoCN每日新闻(2018-11-24)
 
@@ -70,10 +70,10 @@
 4. 如何用Go写业务的表达式引擎 https://medv.io/how-to-write-an-expression-engine/
 5. Go开发跨平台任天堂游戏仿真器 https://github.com/Humpheh/goboy
 
-* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/question/2391
+* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/topics/2391
 
 - 编辑：samurai
-- GoCN归档：https://gocn.vip/question/2400
+- GoCN归档：https://gocn.vip/topics/2400
 
 
 ## GoCN每日新闻(2018-11-25)
@@ -84,4 +84,4 @@
 5. 中台是什么 https://insights.thoughtworks.cn/what-is-zhongtai/
 
 - 编辑: 罗发宣
-- GoCN归档：https://gocn.vip/question/2402
+- GoCN归档：https://gocn.vip/topics/2402

--- a/201811/20181126-20181202.md
+++ b/201811/20181126-20181202.md
@@ -6,10 +6,10 @@
 4. sexp：连接R语言与Go的工具包 https://overthinkdciscores.com/2018/11/20/introducing-sexp-a-package-connecting-r-and-go/
 5. srchx：一个Go实现的轻量级全文搜索工具 https://github.com/alash3al/srchx
 
-* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/question/2391
+* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/topics/2391
 
 * 编辑: 李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2403
+* GoCN归档：https://gocn.vip/topics/2403
 
 ## GoCN每日新闻(2018-11-27)
 
@@ -19,10 +19,10 @@
 4. Kubernetes在上汽集团云平台及AI方面的应用 https://segmentfault.com/a/1190000017150455
 5. Docker 的简单实现 dock https://github.com/philchia/dock
 
-* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/question/2391
+* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/topics/2391
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/2405
+* GoCN归档: https://gocn.vip/topics/2405
 
 
 ## GoCN每日新闻(2018-11-28)
@@ -33,10 +33,10 @@
 4. 用go语言给lua/openresty写扩展 https://zhuanlan.zhihu.com/p/50937409
 5. Go 编译器 nil 指针检查 https://www.ardanlabs.com/blog/2014/09/go-compiler-nil-pointer-checks.html
 
-* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/question/2391
+* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/topics/2391
 
 * 编辑: yulibaozi
-* GoCN归档: https://gocn.vip/question/2406
+* GoCN归档: https://gocn.vip/topics/2406
 
 ## GoCN每日新闻(2018-11-29)  
 
@@ -46,10 +46,10 @@
 4.分布式事务：Saga模式 https://www.jianshu.com/p/e4b662407c66   
 5.使用Prometheus实现对OCI的监控 https://medium.com/@sw_samuraj/oci-monitoring-via-prometheus-service-discovery-851f022f0cdb    
 
-* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/question/2391  
+* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/topics/2391  
 
 * 编辑: Razil  
-* GoCN归档：https://gocn.vip/question/2410  
+* GoCN归档：https://gocn.vip/topics/2410  
 
 ## GoCN每日新闻(2018-11-30)  
 
@@ -59,10 +59,10 @@
 4.使用Go语言写一个DNS服务 https://medium.com/@owlwalks/build-a-dns-server-in-golang-fec346c42889   
 5.vdl: 唯品会开源日志存储系统 https://github.com/vipshop/vdl  
 
-* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/question/2391  
+* 活动: Gopher Meetup 巡回第五站 - 广州 https://gocn.vip/topics/2391  
 
 * 编辑: Razil  
-* GoCN归档：https://gocn.vip/question/2413  
+* GoCN归档：https://gocn.vip/topics/2413  
 
 ## GoCN每日新闻(2018-12-02)
 
@@ -73,4 +73,4 @@
 5. 我为什么关掉了超线程 https://mp.weixin.qq.com/s/GvPxLXLF2bNuVTXaPVM3Ww
 
 编辑: lwhile
-归档: https://gocn.vip/question/2419
+归档: https://gocn.vip/topics/2419

--- a/201812/20181203-20181209.md
+++ b/201812/20181203-20181209.md
@@ -7,7 +7,7 @@
 5. Golang 项目之配置文件 https://juejin.im/post/5c04061bf265da61380ef7aa
 
 - 编辑: 宋佳洋
-- 归档: https://gocn.vip/question/2420
+- 归档: https://gocn.vip/topics/2420
 
 
 ## GoCN每日新闻(2018-12-04)
@@ -19,7 +19,7 @@
 5. 什么是边缘计算：https://medium.com/@miccowang/what-is-edge-computing-f997c0ab39fc
 
 - 编辑: 薛锦
-- GoCN归档:  https://gocn.vip/question/2424
+- GoCN归档:  https://gocn.vip/topics/2424
 
 
 ## GoCN每日新闻(2018-12-05)
@@ -31,7 +31,7 @@
 5. golang后台服务设计 http://litang.me/post/golang-server-design 
 
 - 编辑: 周云轩
-- GoCN归档:  https://gocn.vip/question/2426
+- GoCN归档:  https://gocn.vip/topics/2426
 
 
 ## GoCN每日新闻(2018-12-06)
@@ -43,7 +43,7 @@
 5. 致传统企业朋友：不够痛就别微服务，有坑！ https://mp.weixin.qq.com/s/NUDdVfP0KOnpjXyZjj_IVg 
 
 - 编辑: 崔广章
-- GoCN归档:  https://gocn.vip/question/2427
+- GoCN归档:  https://gocn.vip/topics/2427
 
 
 ## GoCN每日新闻(2018-12-07)
@@ -56,7 +56,7 @@
 
 
 - 编辑: 何小云
-- GoCN归档: https://gocn.vip/question/2429
+- GoCN归档: https://gocn.vip/topics/2429
 
 ## GoCN每日新闻(2018-12-08)
 
@@ -67,7 +67,7 @@
 5. 微软开源的Go跨平台网络诊断工具 https://github.com/Microsoft/Ethr
 
 * 编辑：samurai
-* GoCN归档：https://gocn.vip/question/2431
+* GoCN归档：https://gocn.vip/topics/2431
 
 ## GoCN每日新闻(2018-12-09)
 
@@ -78,4 +78,4 @@
 5. 微服务设计指南 https://mp.weixin.qq.com/s/nYDSZJ-N7ECitDF3AFGgRw
 
 * 编辑：李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2433
+* GoCN归档：https://gocn.vip/topics/2433

--- a/201812/20181210-20181216.md
+++ b/201812/20181210-20181216.md
@@ -7,7 +7,7 @@
 5. 我们如何利用WASM让krakend运行在Javascript环境上 https://medium.com/devops-faith/how-we-run-krakend-on-javascript-with-webassembly-f100ac2efd67
 
 编辑：李俱顺Kevin
-GoCN归档：https://gocn.vip/question/2442
+GoCN归档：https://gocn.vip/topics/2442
 
 ## GoCN每日新闻(2018-12-11)
 
@@ -18,7 +18,7 @@ GoCN归档：https://gocn.vip/question/2442
 5. Go 实现为 SEO 优化的服务端渲染库 https://github.com/rendora/rendora
 
 编辑: 傅小黑
-GoCN归档: https://gocn.vip/question/2443
+GoCN归档: https://gocn.vip/topics/2443
 
 ## GoCN每日新闻(2018-12-12)
 
@@ -29,7 +29,7 @@ GoCN归档: https://gocn.vip/question/2443
 5. CNCF托管etcd https://mp.weixin.qq.com/s/QXIRpbYAAPEirjqf3bJeEQ
 
 编辑: yulibaozi
-GoCN归档: https://gocn.vip/question/2444
+GoCN归档: https://gocn.vip/topics/2444
 
 ## GoCN每日新闻(2018-12-13)
 
@@ -40,7 +40,7 @@ GoCN归档: https://gocn.vip/question/2444
 5. 机器学习的实用方法 https://github.com/GokuMohandas/practicalAI
 
 编辑: 李森森
-GoCN归档：https://gocn.vip/question/2445
+GoCN归档：https://gocn.vip/topics/2445
 
 ## GoCN每日新闻(2018-12-14)  
 
@@ -51,7 +51,7 @@ GoCN归档：https://gocn.vip/question/2445
 5.Docker和Go Modules的搭配使用 https://medium.com/@pliutau/docker-and-go-modules-4265894f9fc  
 
 编辑: Razil  
-归档:  https://gocn.vip/question/2449  
+归档:  https://gocn.vip/topics/2449  
 
 GoCN每日新闻(2018-12-15)
 
@@ -62,7 +62,7 @@ GoCN每日新闻(2018-12-15)
 5. 在Go中探索字节解析API  https://blog.gopheracademy.com/advent-2018/exploring-byte-parsing-apis-in-go/
 
 编辑:马怀博
-归档: https://gocn.vip/question/2451
+归档: https://gocn.vip/topics/2451
 
 
 ## GoCN每日新闻(2018-12-16)
@@ -74,5 +74,5 @@ GoCN每日新闻(2018-12-15)
 5. 理解分布式事务 https://zhuanlan.zhihu.com/p/51684618
 
 编辑: lwhile
-归档: https://gocn.vip/question/2452
+归档: https://gocn.vip/topics/2452
 

--- a/201812/20181217-20181223.md
+++ b/201812/20181217-20181223.md
@@ -7,7 +7,7 @@
 5. 万亿级数据洪峰下的分布式消息引擎 https://mp.weixin.qq.com/s/FuUICaNihx1PPKfxRTN1Fg
 
 - 编辑: 宋佳洋 
-- 归档: https://gocn.vip/question/2455  
+- 归档: https://gocn.vip/topics/2455  
 
 ## GoCN每日新闻(2018-12-18)
 
@@ -18,7 +18,7 @@
 5. 使用 Grafana 和 Prometheus 进行混合云监控： https://medium.com/@anupam.ncsu/grafana-prometheus-hybrid-cloud-monitoring-19907e52c4a1
 
 - 编辑: 薛锦
-- GoCN归档:  https://gocn.vip/question/2457
+- GoCN归档:  https://gocn.vip/topics/2457
 
 ## GoCN每日新闻(2018-12-19)
 
@@ -29,7 +29,7 @@
 5. 万字长文揭秘：阿里如何实现海量数据实时分析？ https://mp.weixin.qq.com/s/kt-xtvM77UZ3kD-3dpU7sw
 
 - 编辑: 周云轩
-- GoCN归档:  https://gocn.vip/question/2465
+- GoCN归档:  https://gocn.vip/topics/2465
 
 ## GoCN每日新闻(2018-12-20)
 
@@ -41,7 +41,7 @@
 5. MySQL PK MongoDB：多文档事务支持，谁更友好？ https://mp.weixin.qq.com/s/dloujdsOHy87cPQkY2oGzg
 
 - 编辑: 崔广章
-- GoCN归档:  https://gocn.vip/question/2468
+- GoCN归档:  https://gocn.vip/topics/2468
 
 ## GoCN每日新闻(2018-12-21)
 
@@ -52,7 +52,7 @@
 5. 京东到家订单中心 Elasticsearch 演进历程 https://mp.weixin.qq.com/s/TrCJJtvhjB2m29fOOa3Rzg
 
 - 编辑: 何小云
-- GoCN归档: https://gocn.vip/question/2470
+- GoCN归档: https://gocn.vip/topics/2470
 
 ## GoCN每日新闻(2018-12-22)
 
@@ -63,7 +63,7 @@
 5. 20个好用的Go语言微服务开发框架 https://mp.weixin.qq.com/s/lb66M8coA_57E4YN3uYJwA
 
 - 编辑：samurai
-- GoCN归档：https://gocn.vip/question/2471
+- GoCN归档：https://gocn.vip/topics/2471
 
 
 ## GoCN每日新闻(2018-12-23)
@@ -74,4 +74,4 @@
 5. netcap:基于安全和可伸缩流量分析的框架 https://github.com/dreadl0ck/netcap
 
 - 编辑: 罗发宣
-- GoCN归档：https://gocn.vip/question/2472
+- GoCN归档：https://gocn.vip/topics/2472

--- a/201812/20181224-20181230.md
+++ b/201812/20181224-20181230.md
@@ -7,7 +7,7 @@
 5. athens与微软 https://medium.com/@arschles/athens-and-microsoft-1b11a316bc23
 
 * 编辑: 李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2473
+* GoCN归档：https://gocn.vip/topics/2473
 
 ## GoCN每日新闻(2018-12-25)
 
@@ -18,7 +18,7 @@
 5. Go 的服务对象模式 https://itnext.io/using-service-objects-in-go-d899dc599335
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/2475
+* GoCN归档: https://gocn.vip/topics/2475
 
 
 ## GoCN每日新闻(2018-12-26)
@@ -30,7 +30,7 @@
 5. makisu 无需特权模式的，快速灵活的 Docker Image构建工具 https://github.com/uber/makisu
 
 * 编辑: yulibaozi
-* GoCN归档：https://gocn.vip/question/2477
+* GoCN归档：https://gocn.vip/topics/2477
 
 ## GoCN每日新闻(2018-12-27)
 
@@ -41,7 +41,7 @@
 5. Go实现的数据压缩 https://github.com/flanglet/kanzi-go
 
 * 编辑: 李森森
-* GoCN归档：https://gocn.vip/question/2478
+* GoCN归档：https://gocn.vip/topics/2478
 
 
 ## GoCN每日新闻(2018-12-28)
@@ -53,7 +53,7 @@
 5. 将curl命令转换为浏览器中的Go代码 https://github.com/mholt/curl-to-go
 
 * 编辑: 李森森
-* GoCN归档：https://gocn.vip/question/2480
+* GoCN归档：https://gocn.vip/topics/2480
 
 ## GoCN每日新闻(2018-12-29)
 
@@ -64,7 +64,7 @@
 5. 什么是区块链预言机 https://juejin.im/post/5c236f456fb9a049c965b9e4
 
 * 编辑: 马怀博
-* GoCN归档: https://gocn.vip/question/2481
+* GoCN归档: https://gocn.vip/topics/2481
 
 ## GoCN每日新闻(2018-12-30)
 
@@ -75,4 +75,4 @@
 5. 分布式系统的基石：深入浅出共识算法 https://zhuanlan.zhihu.com/p/52617675
 
 * 编辑: lwhile
-* 归档: https://gocn.vip/question/2483
+* 归档: https://gocn.vip/topics/2483

--- a/201812/20181231-20190106.md
+++ b/201812/20181231-20190106.md
@@ -7,7 +7,7 @@
 5. 从微服务的角度看，如何 Be Cloud Native：http://t.cn/Ebq3QlD
 
 - 编辑: 薛锦
-- GoCN归档: https://gocn.vip/question/2485
+- GoCN归档: https://gocn.vip/topics/2485
 
 ## GoCN每日新闻(2019-01-01)
 
@@ -18,7 +18,7 @@
 5. 2019 边缘计算和IoT 展望：https://www.rfidjournal.com/articles/view?18111/
 
 - 编辑: 薛锦
-- GoCN归档: https://gocn.vip/question/2488
+- GoCN归档: https://gocn.vip/topics/2488
 
 ## GoCN每日新闻(2019-01-02)
 
@@ -29,7 +29,7 @@
 5. 5G下的微服务架构：拥抱NFV，Istio 1.1将支持多网络平面：https://mp.weixin.qq.com/s/Rn2MdrrV3YahtdnWrfReYA
 
 - 编辑: 崔广章
-- GoCN归档: https://gocn.vip/question/2489
+- GoCN归档: https://gocn.vip/topics/2489
 
 
 ## GoCN每日新闻(2019-01-03)
@@ -41,7 +41,7 @@
 5. 2019年值得关注的23个开发者博客 https://zhuanlan.zhihu.com/p/53729304
 
 - 编辑: 周云轩
-- GoCN归档:  https://gocn.vip/question/2491
+- GoCN归档:  https://gocn.vip/topics/2491
 
 
 ## GoCN每日新闻(2019-01-04)
@@ -53,7 +53,7 @@
 5. Go Docker开发环境使用Go Modules和实时代码实现重载    https://threedots.tech/post/go-docker-dev-environment-with-go-modules-and-live-code-reloading/
 
 - 编辑: 何小云
-- GoCN归档: https://gocn.vip/question/2492
+- GoCN归档: https://gocn.vip/topics/2492
 
 ## GoCN每日新闻(2019-01-05)
 
@@ -64,7 +64,7 @@
 5. 再谈 Go 语言在前端的应用前景 https://mp.weixin.qq.com/s/v0-d-qPQFlV0CxttFpzC5w
 
 - 编辑：samurai
-- GoCN归档：https://gocn.vip/question/2495
+- GoCN归档：https://gocn.vip/topics/2495
 
 ## GoCN每日新闻(2019-01-06)
 GoCN每日新闻(2019-01-06)
@@ -75,5 +75,5 @@ GoCN每日新闻(2019-01-06)
 5. http.DefaultTransport原生支持SOCKS5代理 https://www.reddit.com/r/golang/comments/acqhxu/fun_fact_httpdefaulttransport_natively_supports/
 
 - 编辑: 罗发宣
-- GoCN归档：https://gocn.vip/question/2496
+- GoCN归档：https://gocn.vip/topics/2496
 

--- a/201901/20190107-20190113.md
+++ b/201901/20190107-20190113.md
@@ -9,7 +9,7 @@
 * GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org/
 
 * 编辑: 李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/2498
+* GoCN归档：https://gocn.vip/topics/2498
 
 
 ## GoCN每日新闻(2019-01-08)
@@ -23,7 +23,7 @@
 * GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org/
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.vip/question/2503
+* GoCN归档: https://gocn.vip/topics/2503
 
 ## GoCN每日新闻(2019-01-09)
 
@@ -36,7 +36,7 @@
 * GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org/
 
 * 编辑: yulibaozi
-* GoCN归档: https://gocn.vip/question/2505
+* GoCN归档: https://gocn.vip/topics/2505
 
 ## GoCN每日新闻(2019-01-10)
 
@@ -49,7 +49,7 @@
 * GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org/
 
 * 编辑: 李森森
-* GoCN归档：https://gocn.vip/question/2507
+* GoCN归档：https://gocn.vip/topics/2507
 
 ## GoCN每日新闻(2019-01-11)
 
@@ -62,7 +62,7 @@
 * GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org/    
 
 * 编辑: Razil  
-* GoCN归档：https://gocn.vip/question/2511  
+* GoCN归档：https://gocn.vip/topics/2511  
 
 ## GoCN每日新闻(2019-01-12)
 
@@ -75,7 +75,7 @@
 * GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org/
 
 * 编辑: 马怀博
-* GoCN归档: https://gocn.vip/question/2514
+* GoCN归档: https://gocn.vip/topics/2514
 
 GoCN每日新闻(2019-01-13)
 
@@ -88,4 +88,4 @@ GoCN每日新闻(2019-01-13)
 * GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org/
 
 * 编辑: lwhile
-* GoCN归档: https://gocn.vip/question/2515
+* GoCN归档: https://gocn.vip/topics/2515

--- a/201901/20190114-20190120.md
+++ b/201901/20190114-20190120.md
@@ -8,7 +8,7 @@
 
 - GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org
 - 编辑: 宋佳洋
-- GoCN归档: https://gocn.vip/question/2516
+- GoCN归档: https://gocn.vip/topics/2516
 
 ## GoCN每日新闻(2019-01-15)
 
@@ -20,7 +20,7 @@
 
 - GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org
 - 编辑: 宋佳洋
-- GoCN归档: https://gocn.vip/question/2517
+- GoCN归档: https://gocn.vip/topics/2517
 
 ## GoCN每日新闻(2019-01-16)
 
@@ -32,7 +32,7 @@
 
 - GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org
 - 编辑: 周云轩
-- GoCN归档: https://gocn.vip/question/3061
+- GoCN归档: https://gocn.vip/topics/3061
 
 ## GoCN每日新闻(2019-01-17)
 
@@ -45,7 +45,7 @@
 - GopherChina 2019@北京，早鸟票已开售 https://gopherchina.org
 
 - 编辑: 崔广章
-- GoCN归档: https://gocn.vip/question/3066
+- GoCN归档: https://gocn.vip/topics/3066
 
 ## GoCN每日新闻(2019-01-19)
 
@@ -58,7 +58,7 @@
 - 探探 Gopher China 2019大会全面启动 https://mp.weixin.qq.com/s/h3b5W35jhKN5daU7dQrNEw
 
 - 编辑：samurai
-- GoCN归档：https://gocn.vip/question/3073
+- GoCN归档：https://gocn.vip/topics/3073
 
 ## GoCN每日新闻(2019-01-20)
 1. Task:go运行/构建工具 https://taskfile.org/
@@ -70,4 +70,4 @@
 - 探探GopherChina2019大会全面启动 https://mp.weixin.qq.com/s/h3b5W35jhKN5daU7dQrNEw
 
 - 编辑: 罗发宣
-- GoCN归档：https://gocn.vip/question/3074
+- GoCN归档：https://gocn.vip/topics/3074

--- a/201901/20190121-20190127.md
+++ b/201901/20190121-20190127.md
@@ -9,7 +9,7 @@
 * 探探GopherChina2019大会全面启动 https://mp.weixin.qq.com/s/h3b5W35jhKN5daU7dQrNEw
 
 * 编辑: 李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/3079
+* GoCN归档：https://gocn.vip/topics/3079
 
 ## GoCN每日新闻(2019-01-23)
 
@@ -22,7 +22,7 @@
 * 早鸟票仅剩有限名额，大家抓紧啦 https://www.bagevent.com/event/gocn5th
 
 * 编辑: yulibaozi
-* GoCN归档: https://gocn.vip/question/3087
+* GoCN归档: https://gocn.vip/topics/3087
 
 
 ## GoCN每日新闻(2019-01-24)
@@ -36,7 +36,7 @@
 * 早鸟票仅剩有限名额，大家抓紧啦 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 李森森
-* GoCN归档：https://gocn.vip/question/3091
+* GoCN归档：https://gocn.vip/topics/3091
 
 ## GoCN每日新闻(2019-01-25) 
 
@@ -49,7 +49,7 @@
 * 早鸟票仅剩有限名额，大家抓紧啦 https://www.bagevent.com/event/gocn5th 
 
 * 编辑: Razil 
-* GoCN归档：https://gocn.vip/question/3095
+* GoCN归档：https://gocn.vip/topics/3095
 
 ## GoCN每日新闻(2019-01-26)
 
@@ -62,7 +62,7 @@
 * 早鸟票仅剩有限名额，大家抓紧啦 https://www.bagevent.com/event/gocn5th 
 
 * 编辑: 马怀博
-* GoCN归档：https://gocn.vip/question/3097
+* GoCN归档：https://gocn.vip/topics/3097
 
 ## GoCN每日新闻(2019-01-27)
 
@@ -75,4 +75,4 @@
 * 早鸟票仅剩有限名额，大家抓紧啦 https://www.bagevent.com/event/gocn5th
 
 * 编辑: lwhile
-* 归档: https://gocn.vip/question/3099
+* 归档: https://gocn.vip/topics/3099

--- a/201901/20190128-20190203.md
+++ b/201901/20190128-20190203.md
@@ -9,7 +9,7 @@
 - 早鸟票仅剩有限名额，大家抓紧啦 https://www.bagevent.com/event/gocn5th
 
 - 编辑: 薛锦
-- GoCN归档: https://gocn.vip/question/3100
+- GoCN归档: https://gocn.vip/topics/3100
 
 ## GoCN每日新闻(2019-01-29)
 
@@ -22,7 +22,7 @@
 - 早鸟票仅剩有限名额，大家抓紧啦 https://www.bagevent.com/event/gocn5th
 
 - 编辑: 宋佳洋
-- GoCN归档: https://gocn.vip/question/3101
+- GoCN归档: https://gocn.vip/topics/3101
 
 ## GoCN每日新闻(2019-01-30)
 
@@ -35,7 +35,7 @@
 - 最后两天早鸟票 https://www.bagevent.com/event/gocn5th
 
 - 编辑: 周云轩
-- GoCN归档: https://gocn.vip/question/3102
+- GoCN归档: https://gocn.vip/topics/3102
 
 ## GoCN每日新闻(2019-01-31)
 
@@ -48,7 +48,7 @@
 - 最后一天早鸟票 https://www.bagevent.com/event/gocn5th
 
 - 编辑: 崔广章
-- GoCN归档: https://gocn.vip/question/3105
+- GoCN归档: https://gocn.vip/topics/3105
 
 
 ## GoCN每日新闻(2019-02-01)
@@ -62,7 +62,7 @@
 - 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 - 编辑: 何小云
-- GoCN归档: https://gocn.vip/question/3106
+- GoCN归档: https://gocn.vip/topics/3106
 
 
 ## GoCN每日新闻(2019-02-02)
@@ -74,4 +74,4 @@
 5. Golang写webassembly的乐趣 https://medium.com/@martinolsansky/webassembly-with-golang-is-fun-b243c0e34f02
 
 - 编辑：samurai
-- GoCN归档：https://gocn.vip/question/3107
+- GoCN归档：https://gocn.vip/topics/3107

--- a/201902/20190204-20190210.md
+++ b/201902/20190204-20190210.md
@@ -7,10 +7,10 @@
 5. Go中的光线追踪 https://github.com/hunterloftis/oneweekend/blob/master/readme.md
 
 * GOCN每日新闻小组祝大家新年快乐，身体健康，万事如意，心想事成！
-* GopherconChina2019部分议题已确定 https://gocn.vip/question/3109
+* GopherconChina2019部分议题已确定 https://gocn.vip/topics/3109
 
 * 编辑: 李俱顺Kevin
-* GoCN归档: https://gocn.vip/question/3110
+* GoCN归档: https://gocn.vip/topics/3110
 
 ## GoCN每日新闻(2019-02-05)
 
@@ -23,7 +23,7 @@
 * 祝福所有 Gopher 朋友新年快乐
 
 * 编辑: 傅小黑
-* GoCN归档: https://gocn.io/question/3111
+* GoCN归档: https://gocn.vip/topics/3111
 
 ## GoCN每日新闻(2019-02-06)
 
@@ -36,7 +36,7 @@
 * 祝福所有 Gopher 朋友新年快乐
 
 * 编辑: yulibaozi
-* GoCN归档: https://gocn.vip/question/3112
+* GoCN归档: https://gocn.vip/topics/3112
 
 ## GoCN每日新闻(2019-02-07)
 
@@ -49,7 +49,7 @@
 * 祝福所有 Gopher 朋友新年快乐
 
 * 编辑: 李森森
-* GoCN归档: https://gocn.vip/question/3113
+* GoCN归档: https://gocn.vip/topics/3113
 
 ## GoCN每日新闻(2019-02-08)
 
@@ -62,7 +62,7 @@
 * 祝福所有 Gopher 朋友新年快乐
 
 * 编辑: 马怀博 
-* GoCN归档: https://gocn.vip/question/3114
+* GoCN归档: https://gocn.vip/topics/3114
 
 ## GoCN每日新闻(2019-02-09)
 
@@ -75,7 +75,7 @@
 * 祝福所有 Gopher 朋友新年快乐
 
 * 编辑: Razil 
-* GoCN归档: https://gocn.vip/question/3116
+* GoCN归档: https://gocn.vip/topics/3116
 
 ## GoCN每日新闻(2019-02-10)
 
@@ -86,4 +86,4 @@
 5. 微服务进化史 https://juejin.im/post/5c5ed33cf265da2dc6759392
 
 * 编辑: lwhile
-* GoCN归档: https://gocn.vip/question/3118
+* GoCN归档: https://gocn.vip/topics/3118

--- a/201902/20190211-20190217.md
+++ b/201902/20190211-20190217.md
@@ -9,7 +9,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 宋佳洋
-* GoCN归档: https://gocn.vip/question/3119
+* GoCN归档: https://gocn.vip/topics/3119
 
 ## GoCN每日新闻(2019-02-12)
 
@@ -22,7 +22,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 薛锦
-* GoCN归档: https://gocn.vip/question/3120
+* GoCN归档: https://gocn.vip/topics/3120
 
 ## GoCN每日新闻(2019-02-13)
 
@@ -35,7 +35,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 周云轩
-* GoCN归档: https://gocn.vip/question/3122
+* GoCN归档: https://gocn.vip/topics/3122
 
 
 ## GoCN每日新闻(2019-02-14)
@@ -49,7 +49,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 崔广章
-* GoCN归档: https://gocn.vip/question/3124
+* GoCN归档: https://gocn.vip/topics/3124
 
 
 ## GoCN每日新闻(2019-02-15)
@@ -63,7 +63,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 何小云
-* GoCN归档: https://gocn.vip/question/3125
+* GoCN归档: https://gocn.vip/topics/3125
 
 ## GoCN每日新闻(2019-02-16)
 
@@ -76,7 +76,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑：samurai
-* GoCN归档：https://gocn.vip/question/3127
+* GoCN归档：https://gocn.vip/topics/3127
 
 ## GoCN每日新闻(2019-02-17)
 
@@ -89,4 +89,4 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 罗发宣
-* GoCN归档：https://gocn.vip/question/3129
+* GoCN归档：https://gocn.vip/topics/3129

--- a/201902/20190218-20190224.md
+++ b/201902/20190218-20190224.md
@@ -9,7 +9,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 李俱顺Kevin
-* GoCN归档：https://gocn.vip/question/3130
+* GoCN归档：https://gocn.vip/topics/3130
 
 ## GoCN每日新闻(2019-02-19)
 
@@ -23,7 +23,7 @@
 * 祝福所有 Gopher 朋友元宵节快乐
 
 编辑: 傅小黑
-GoCN归档: https://gocn.io/question/3131
+GoCN归档: https://gocn.vip/topics/3131
 
 ## GoCN每日新闻(2019-02-20)
 
@@ -36,7 +36,7 @@ GoCN归档: https://gocn.io/question/3131
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 编辑: yulibaozi
-GoCN归档: https://gocn.vip/question/3134
+GoCN归档: https://gocn.vip/topics/3134
 
 ## GoCN每日新闻(2019-02-21)
 
@@ -49,7 +49,7 @@ GoCN归档: https://gocn.vip/question/3134
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 李森森
-* GoCN归档： https://gocn.vip/question/3135
+* GoCN归档： https://gocn.vip/topics/3135
 * 订阅新闻: http://tinyletter.com/gocn
 
 ## GoCN每日新闻(2019-02-22) 
@@ -63,7 +63,7 @@ GoCN归档: https://gocn.vip/question/3134
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th   
 
 * 编辑: Razil  
-* GoCN归档： https://gocn.vip/question/3136  
+* GoCN归档： https://gocn.vip/topics/3136  
 * 订阅新闻: http://tinyletter.com/gocn
 
 
@@ -78,5 +78,5 @@ GoCN归档: https://gocn.vip/question/3134
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th   
 
 * 编辑: lwhile
-* GoCN归档: https://gocn.vip/question/3139
+* GoCN归档: https://gocn.vip/topics/3139
 * 订阅新闻: http://tinyletter.com/gocn

--- a/201902/20190225-20190303.md
+++ b/201902/20190225-20190303.md
@@ -9,7 +9,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 宋佳洋
-* GoCN归档: https://gocn.vip/question/3141
+* GoCN归档: https://gocn.vip/topics/3141
 * 订阅新闻: http://tinyletter.com/gocn
 
 ## GoCN每日新闻(2019-02-26)
@@ -24,7 +24,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3143
+- GoCN归档: https://gocn.vip/topics/3143
 
 ## GoCN每日新闻(2019-02-27)
 
@@ -38,7 +38,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3146
+- GoCN归档: https://gocn.vip/topics/3146
 
 ## GoCN每日新闻(2019-02-28)
 
@@ -52,7 +52,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3148
+- GoCN归档: https://gocn.vip/topics/3148
 
 ## GoCN每日新闻(2019-03-02)
 
@@ -67,7 +67,7 @@ https://www.infoq.cn/article/96KL3BQwqz-IzxYi2wUO
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3151
+- GoCN归档：https://gocn.vip/topics/3151
 
 ## GoCN每日新闻(2019-03-03)
 1. 支持百万连接服务器的benchmark实现 https://github.com/smallnest/1m-go-tcp-server
@@ -80,4 +80,4 @@ https://www.infoq.cn/article/96KL3BQwqz-IzxYi2wUO
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3152
+- GoCN归档：https://gocn.vip/topics/3152

--- a/201903/20190304-20190310.md
+++ b/201903/20190304-20190310.md
@@ -10,7 +10,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3155
+* GoCN归档：https://gocn.vip/topics/3155
 
 
 ## GoCN每日新闻(2019-03-05)
@@ -24,7 +24,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 编辑: 傅小黑
-GoCN归档: https://gocn.io/question/3158
+GoCN归档: https://gocn.vip/topics/3158
 
 ## GoCN每日新闻(2019-03-06)
 
@@ -38,7 +38,7 @@ GoCN归档: https://gocn.io/question/3158
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/3161
+GoCN归档: https://gocn.vip/topics/3161
 
 
 ## GoCN每日新闻(2019-03-07)
@@ -52,7 +52,7 @@ GoCN归档: https://gocn.io/question/3161
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th
 
 * 编辑: 李森森
-* GoCN归档：https://gocn.vip/question/3162
+* GoCN归档：https://gocn.vip/topics/3162
 
 ## GoCN每日新闻(2019-03-08)
 
@@ -65,7 +65,7 @@ GoCN归档: https://gocn.io/question/3161
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th  
 
 * 编辑: Razil  
-* GoCN归档：https://gocn.vip/question/3165  
+* GoCN归档：https://gocn.vip/topics/3165  
 
 ## GoCN每日新闻(2019-03-09)
 
@@ -78,7 +78,7 @@ GoCN归档: https://gocn.io/question/3161
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th  
 
 * 编辑: 马怀博
-* GoCN归档：https://gocn.vip/question/3168
+* GoCN归档：https://gocn.vip/topics/3168
 
 ## GoCN每日新闻(2019-03-10)
 
@@ -91,4 +91,4 @@ GoCN归档: https://gocn.io/question/3161
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th  
 
 * 编辑: Razil  
-* GoCN归档：https://gocn.vip/question/3170
+* GoCN归档：https://gocn.vip/topics/3170

--- a/201903/20190311-20190317.md
+++ b/201903/20190311-20190317.md
@@ -9,7 +9,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th  
 
 * 编辑: 宋佳洋 
-* GoCN归档：https://gocn.vip/question/3171
+* GoCN归档：https://gocn.vip/topics/3171
 * 订阅新闻: http://tinyletter.com/gocn
 
 
@@ -24,7 +24,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th  
 
 * 编辑: 薛锦
-* GoCN归档：https://gocn.vip/question/3172
+* GoCN归档：https://gocn.vip/topics/3172
 * 订阅新闻: http://tinyletter.com/gocn
 
 
@@ -39,7 +39,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th  
 
 * 编辑: 周云轩
-* GoCN归档：https://gocn.vip/question/3178
+* GoCN归档：https://gocn.vip/topics/3178
 * 订阅新闻: http://tinyletter.com/gocn
 
 ## GoCN每日新闻(2019-03-14)
@@ -53,7 +53,7 @@
 * 第五届GopherChina大会门票 https://www.bagevent.com/event/gocn5th  
 
 * 编辑: 崔广章
-* GoCN归档：https://gocn.vip/question/3183
+* GoCN归档：https://gocn.vip/topics/3183
 * 订阅新闻: http://tinyletter.com/gocn
 
 ## GoCN每日新闻(2019-03-16)
@@ -68,7 +68,7 @@
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3193
+* GoCN归档：https://gocn.vip/topics/3193
 
 
 ## GoCN每日新闻(2019-03-17) 
@@ -82,4 +82,4 @@
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3194
+* GoCN归档：https://gocn.vip/topics/3194

--- a/201903/20190318-20190324.md
+++ b/201903/20190318-20190324.md
@@ -10,7 +10,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3196
+* GoCN归档：https://gocn.vip/topics/3196
 
 ## GoCN每日新闻(2019-03-19)
 
@@ -24,7 +24,7 @@
 
 编辑: 傅小黑
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/3204
+GoCN归档: https://gocn.vip/topics/3204
 
 ## GoCN每日新闻(2019-03-20)
 
@@ -38,7 +38,7 @@ GoCN归档: https://gocn.io/question/3204
 
 编辑: yulibaozi
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/3206
+GoCN归档: https://gocn.vip/topics/3206
 
 ## GoCN每日新闻(2019-03-21)
 
@@ -52,7 +52,7 @@ GoCN归档: https://gocn.vip/question/3206
 
 编辑: 李森森
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档：https://gocn.vip/question/3208
+GoCN归档：https://gocn.vip/topics/3208
 
 ## GoCN每日新闻(2019-03-22)
 
@@ -66,7 +66,7 @@ GoCN归档：https://gocn.vip/question/3208
 
 编辑: lwhile
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/3213
+GoCN归档: https://gocn.vip/topics/3213
 
 ## GoCN每日新闻(2019-03-23)
 
@@ -80,7 +80,7 @@ GoCN归档: https://gocn.vip/question/3213
 
 编辑: 马怀博 
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/3215
+GoCN归档: https://gocn.vip/topics/3215
 
 ## GoCN每日新闻(2019-03-24)
 
@@ -94,4 +94,4 @@ GoCN归档: https://gocn.vip/question/3215
 
 编辑: lwhile
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/3216
+GoCN归档: https://gocn.vip/topics/3216

--- a/201903/20190325-20190331.md
+++ b/201903/20190325-20190331.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3217
+- GoCN归档: https://gocn.vip/topics/3217
 
 
 ## GoCN每日新闻(2019-03-26)
@@ -25,7 +25,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3221
+- GoCN归档: https://gocn.vip/topics/3221
 
 ## GoCN每日新闻(2019-03-27)
 
@@ -39,7 +39,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3222
+- GoCN归档: https://gocn.vip/topics/3222
 
 
 ## GoCN每日新闻(2019-03-28)
@@ -54,7 +54,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3223
+- GoCN归档: https://gocn.vip/topics/3223
 
 ## GoCN每日新闻(2019-03-30)
 
@@ -68,7 +68,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3227
+- GoCN归档：https://gocn.vip/topics/3227
 
 
 ## GoCN每日新闻(2019-03-31) 
@@ -80,4 +80,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3228
+- GoCN归档：https://gocn.vip/topics/3228

--- a/201904/20190401-20190407.md
+++ b/201904/20190401-20190407.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3230
+* GoCN归档：https://gocn.vip/topics/3230
 
 
 ## GoCN每日新闻(2019-04-02)
@@ -23,7 +23,7 @@
 
 编辑: 傅小黑
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/3234
+GoCN归档: https://gocn.vip/topics/3234
 
 ## GoCN每日新闻(2019-04-03)
 
@@ -37,7 +37,7 @@ GoCN归档: https://gocn.io/question/3234
 
 编辑: yulibaozi
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/3236
+GoCN归档: https://gocn.vip/topics/3236
 
 ## GoCN每日新闻(2019-04-04)
 
@@ -51,7 +51,7 @@ GoCN归档: https://gocn.vip/question/3236
 
 编辑: 李森森
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档：https://gocn.vip/question/3240
+GoCN归档：https://gocn.vip/topics/3240
 
 ## GoCN每日新闻(2019-04-05)
 
@@ -65,7 +65,7 @@ GoCN归档：https://gocn.vip/question/3240
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3245
+* GoCN归档: https://gocn.vip/topics/3245
 
 ## GoCN每日新闻(2019-04-06)
 
@@ -79,7 +79,7 @@ GoCN归档：https://gocn.vip/question/3240
 
 * 编辑: 马怀博
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3246
+* GoCN归档：https://gocn.vip/topics/3246
 
 ## GoCN每日新闻(2019-04-07)
 
@@ -92,5 +92,5 @@ GoCN归档：https://gocn.vip/question/3240
 * 粉丝福利 | 第五届 Gopher China大会门票福利第二波 https://mp.weixin.qq.com/s/4q-FpHsKu_t_7St65svT5w
 
 * 编辑: lwhile
-* GoCN归档：https://gocn.vip/question/3248
+* GoCN归档：https://gocn.vip/topics/3248
 * 订阅新闻: http://tinyletter.com/gocn

--- a/201904/20190408-20190414.md
+++ b/201904/20190408-20190414.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3252
+- GoCN归档: https://gocn.vip/topics/3252
 
 ## GoCN每日新闻(2019-04-09)
 
@@ -24,7 +24,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3253
+- GoCN归档: https://gocn.vip/topics/3253
 
 ## GoCN每日新闻(2019-04-10)
 
@@ -38,7 +38,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3255
+- GoCN归档: https://gocn.vip/topics/3255
 
 
 ## GoCN每日新闻(2019-04-11)
@@ -53,7 +53,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3258
+- GoCN归档: https://gocn.vip/topics/3258
 
 ## GoCN每日新闻(2019-04-13)
 
@@ -67,4 +67,4 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3261
+- GoCN归档：https://gocn.vip/topics/3261

--- a/201904/20190415-20190421.md
+++ b/201904/20190415-20190421.md
@@ -10,7 +10,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3267
+* GoCN归档: https://gocn.vip/topics/3267
 
 ## GoCN每日新闻(2019-04-16)
 
@@ -24,7 +24,7 @@
 
 - 编辑: 傅小黑
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3270
+- GoCN归档: https://gocn.vip/topics/3270
 
 
 ## GoCN每日新闻(2019-04-17)
@@ -39,7 +39,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3271
+* GoCN归档: https://gocn.vip/topics/3271
 
 ## GoCN每日新闻(2019-04-18)
 
@@ -53,7 +53,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3272
+* GoCN归档：https://gocn.vip/topics/3272
 
 ## GoCN每日新闻(2019-04-19)
 
@@ -67,7 +67,7 @@
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3273
+* GoCN归档：https://gocn.vip/topics/3273
 
 
 ## GoCN每日新闻(2019-04-20)
@@ -82,7 +82,7 @@
 
 * 编辑: 马怀博
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3277
+* GoCN归档: https://gocn.vip/topics/3277
 
 ## GoCN每日新闻(2019-04-21)
 
@@ -96,4 +96,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3279
+* GoCN归档: https://gocn.vip/topics/3279

--- a/201904/20190422-20190428.md
+++ b/201904/20190422-20190428.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3280
+- GoCN归档: https://gocn.vip/topics/3280
 
 ## GoCN每日新闻(2019-04-23)
 
@@ -24,7 +24,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3282
+- GoCN归档: https://gocn.vip/topics/3282
 
 ## GoCN每日新闻(2019-04-24)
 
@@ -38,7 +38,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3284
+- GoCN归档: https://gocn.vip/topics/3284
 
 ## GoCN每日新闻(2019-04-25)
 
@@ -52,7 +52,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3288
+- GoCN归档: https://gocn.vip/topics/3288
 
 
 ## GoCN每日新闻(2019-04-27）
@@ -65,7 +65,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3293
+- GoCN归档: https://gocn.vip/topics/3293
 
 ## GoCN每日新闻(2019-04-28）
 
@@ -77,4 +77,4 @@
 
 编辑: 罗发宣
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/3295
+GoCN归档: https://gocn.vip/topics/3295

--- a/201904/20190429-20190505.md
+++ b/201904/20190429-20190505.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3298
+* GoCN归档: https://gocn.vip/topics/3298
 
 
 ## GoCN每日新闻(2019-04-30)
@@ -21,7 +21,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3307
+* GoCN归档: https://gocn.vip/topics/3307
 
 ## GoCN每日新闻(2019-05-01)
 
@@ -33,7 +33,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3308
+* GoCN归档: https://gocn.vip/topics/3308
 
 ## GoCN每日新闻(2019-05-02)
 
@@ -45,7 +45,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3310
+* GoCN归档：https://gocn.vip/topics/3310
 
 ## GoCN每日新闻(2019-05-03)
   
@@ -57,7 +57,7 @@
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3311
+* GoCN归档：https://gocn.vip/topics/3311
 
 ## GoCN每日新闻(2019-05-04)
 
@@ -69,7 +69,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3313
+* GoCN归档：https://gocn.vip/topics/3313
 
 ## GoCN每日新闻(2019-05-05)
 
@@ -81,4 +81,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3314
+* GoCN归档：https://gocn.vip/topics/3314

--- a/201905/20190506-20190512.md
+++ b/201905/20190506-20190512.md
@@ -8,7 +8,7 @@
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3317
+* GoCN归档：https://gocn.vip/topics/3317
 
 
 ## GoCN每日新闻(2019-05-07)
@@ -21,7 +21,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3319
+- GoCN归档：https://gocn.vip/topics/3319
 
 ## GoCN每日新闻(2019-05-08)
 
@@ -33,7 +33,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3320
+- GoCN归档: https://gocn.vip/topics/3320
 
 ## GoCN每日新闻(2019-05-09)
 
@@ -46,7 +46,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3322
+- GoCN归档: https://gocn.vip/topics/3322
 
 ## GoCN每日新闻(2019-05-11)
 
@@ -58,7 +58,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3326
+- GoCN归档：https://gocn.vip/topics/3326
 
 
 ## GoCN每日新闻(2019-05-12) 
@@ -70,4 +70,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3327
+- GoCN归档：https://gocn.vip/topics/3327

--- a/201905/20190513-20190519.md
+++ b/201905/20190513-20190519.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3329
+* GoCN归档：https://gocn.vip/topics/3329
 
 ## GoCN每日新闻(2019-05-14)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 傅小黑  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档: https://gocn.vip/question/3330
+* GoCN归档: https://gocn.vip/topics/3330
 
 ## GoCN每日新闻(2019-05-15)
 
@@ -32,7 +32,7 @@
 
 * 编辑: Razil  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档: https://gocn.vip/question/3332
+* GoCN归档: https://gocn.vip/topics/3332
 
 
 ## GoCN每日新闻(2019-05-16)
@@ -45,7 +45,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3334
+* GoCN归档：https://gocn.vip/topics/3334
 
 
 ## GoCN每日新闻(2019-05-17)
@@ -58,7 +58,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3336
+* GoCN归档：https://gocn.vip/topics/3336
 
 ## GoCN每日新闻(2019-05-18)
 
@@ -70,7 +70,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3339
+* GoCN归档: https://gocn.vip/topics/3339
 
 ## GoCN每日新闻(2019-05-19)
 
@@ -82,4 +82,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3340
+* GoCN归档: https://gocn.vip/topics/3340

--- a/201905/20190520-20190526.md
+++ b/201905/20190520-20190526.md
@@ -8,7 +8,7 @@
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3342
+* GoCN归档: https://gocn.vip/topics/3342
 
 ## GoCN每日新闻(2019-05-21)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 薛锦
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3344
+* GoCN归档: https://gocn.vip/topics/3344
 
 ## GoCN每日新闻(2019-05-22)
 
@@ -32,7 +32,7 @@
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3349
+* GoCN归档: https://gocn.vip/topics/3349
 
 
 ## GoCN每日新闻(2019-05-23）
@@ -45,7 +45,7 @@
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3350
+* GoCN归档: https://gocn.vip/topics/3350
 
 ## GoCN每日新闻(2019-05-25)
 
@@ -57,7 +57,7 @@
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3356
+* GoCN归档: https://gocn.vip/topics/3356
 
 ## GoCN每日新闻(2019-05-26)
 
@@ -69,4 +69,4 @@
 
 * 编辑: 崔广章
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3357
+* GoCN归档: https://gocn.vip/topics/3357

--- a/201905/20190527-20190602.md
+++ b/201905/20190527-20190602.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3358
+* GoCN归档: https://gocn.vip/topics/3358
 
 ## GoCN每日新闻(2019-05-28)
 
@@ -20,19 +20,19 @@
 
 编辑: 傅小黑
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/3373
+GoCN归档: https://gocn.vip/topics/3373
 
 ## GoCN每日新闻(2019-05-29)
 
 1.  [译]Go如何优雅的处理异常 https://mp.weixin.qq.com/s/GEWy8AQg5WmlX3POearpZQ
-2. Micro源码系列 - Go-Micro服务的构造过程 https://gocn.vip/question/3379
+2. Micro源码系列 - Go-Micro服务的构造过程 https://gocn.vip/topics/3379
 3. Go内存管理 https://povilasv.me/go-memory-management-part-2/
 4. gobox中的异常定义和杂项工具 https://mp.weixin.qq.com/s/F-T9aoo3-DMAEr8-dzsenQ
 5. Go 1.12 移植到 RISC-V 的进展 https://www.reddit.com/r/golang/comments/bu4l0p/progress_on_the_go_112_port_to_riscv/
 
 编辑: yulibaozi
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/3380
+GoCN归档: https://gocn.vip/topics/3380
 
 ## GoCN每日新闻(2019-05-30)
 
@@ -44,7 +44,7 @@ GoCN归档: https://gocn.vip/question/3380
 
 编辑: 李森森
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档：https://gocn.vip/question/3381
+GoCN归档：https://gocn.vip/topics/3381
 
 ## GoCN每日新闻(2019-05-31)
 
@@ -56,7 +56,7 @@ GoCN归档：https://gocn.vip/question/3381
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3385
+* GoCN归档：https://gocn.vip/topics/3385
 
 ## GoCN每日新闻(2019-06-01)
 
@@ -68,7 +68,7 @@ GoCN归档：https://gocn.vip/question/3381
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* https://gocn.vip/question/3388
+* https://gocn.vip/topics/3388
 
 ## GoCN每日新闻(2019-06-02)
 
@@ -80,4 +80,4 @@ GoCN归档：https://gocn.vip/question/3381
 
 * 编辑： lwhile
 * 订阅新闻： http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3405
+* GoCN归档：https://gocn.vip/topics/3405

--- a/201906/20190603-20190609.md
+++ b/201906/20190603-20190609.md
@@ -8,7 +8,7 @@
 
 * 编辑：宋佳洋
 * 订阅新闻：http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3406
+* GoCN归档：https://gocn.vip/topics/3406
 
 
 ## GoCN每日新闻(2019-06-04)
@@ -21,7 +21,7 @@
 
 - 编辑：薛锦
 - 订阅新闻：http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3408
+- GoCN归档：https://gocn.vip/topics/3408
 
 
 ## GoCN每日新闻(2019-06-05)
@@ -34,7 +34,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3414
+- GoCN归档: https://gocn.vip/topics/3414
 
 ## GoCN每日新闻(2019-06-06)
 
@@ -46,7 +46,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3418
+- GoCN归档: https://gocn.vip/topics/3418
 
 ## GoCN每日新闻(2019-06-07)
 
@@ -58,7 +58,7 @@
 
 - 编辑: Asta
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3423
+- GoCN归档: https://gocn.vip/topics/3423
 
 ## GoCN每日新闻(2019-06-08)
 
@@ -70,7 +70,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3424
+- GoCN归档: https://gocn.vip/topics/3424
 
 ## GoCN每日新闻(2019-06-09) 
 1. Golang并发编程与Context https://draveness.me/golang-context
@@ -81,4 +81,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3425
+- GoCN归档：https://gocn.vip/topics/3425

--- a/201906/20190610-20190616.md
+++ b/201906/20190610-20190616.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3426
+* GoCN归档：https://gocn.vip/topics/3426
 
 ## GoCN每日新闻(2019-06-11)
 
@@ -18,11 +18,11 @@
 4. Rabbit 轻量级 Go 编译平台 https://github.com/Clivern/Rabbit
 5. Go 操作 CSV 数据 https://medium.com/@barunthapa/working-with-csv-in-go-50a4f540e623
 
-* [上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/question/1803
+* [上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/topics/1803
 
 编辑: 傅小黑
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/3430
+GoCN归档: https://gocn.vip/topics/3430
 
 ## GoCN每日新闻(2019-06-12)
 
@@ -33,11 +33,11 @@ GoCN归档: https://gocn.io/question/3430
 5. [译] Go语言使用TCP keepalive https://www.pengrl.com/p/62417/
 
 
-* [上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/question/1803
+* [上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/topics/1803
 
 编辑: yulibaozi
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.io/question/3433
+GoCN归档: https://gocn.vip/topics/3433
 
 
 
@@ -49,11 +49,11 @@ GoCN归档: https://gocn.io/question/3433
 4. 构建Go代码的三种方法 https://www.perimeterx.com/blog/ok-lets-go/
 5. 在Go中实现可恢复的异常系统 https://rauhl.com/2019/06/implementing-a-resumable-exception-system-in-go/
 
-* [上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/question/1803
+* [上海徐汇] 积梦智能招聘Go工程师 https://gocn.vip/topics/1803
 
 编辑: 李森森
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档：https://gocn.vip/question/3436
+GoCN归档：https://gocn.vip/topics/3436
 
 ## GoCN每日新闻(2019-06-14)
 
@@ -65,7 +65,7 @@ GoCN归档：https://gocn.vip/question/3436
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3439
+* GoCN归档：https://gocn.vip/topics/3439
 
 ## GoCN每日新闻(2019-06-15)
 
@@ -77,7 +77,7 @@ GoCN归档：https://gocn.vip/question/3436
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3440
+* GoCN归档：https://gocn.vip/topics/3440
 
 ## GoCN每日新闻(2019-06-16)
 
@@ -89,5 +89,5 @@ GoCN归档：https://gocn.vip/question/3436
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3442
+* GoCN归档：https://gocn.vip/topics/3442
 

--- a/201906/20190617-20190623.md
+++ b/201906/20190617-20190623.md
@@ -8,7 +8,7 @@
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3443
+* GoCN归档：https://gocn.vip/topics/3443
 
 
 ## GoCN每日新闻(2019-06-18)
@@ -21,7 +21,7 @@
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3446
+* GoCN归档: https://gocn.vip/topics/3446
 
 ## GoCN每日新闻(2019-06-19)
 
@@ -33,7 +33,7 @@
 
 * 编辑: 薛锦 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3447
+* GoCN归档: https://gocn.vip/topics/3447
 
 
 
@@ -47,7 +47,7 @@
 
 * 编辑: 崔广章 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3450
+* GoCN归档: https://gocn.vip/topics/3450
 
 
 
@@ -61,7 +61,7 @@
 
 * 编辑: 何小云
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3502
+* GoCN归档: https://gocn.vip/topics/3502
 
 ## GoCN每日新闻(2019-06-22)
 
@@ -73,7 +73,7 @@
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3505
+* GoCN归档: https://gocn.vip/topics/3505
 
 ## GoCN每日新闻(2019-06-23) 
 1. Golang手把手实现tcp内网穿透代理 https://www.jianshu.com/p/e79fe205f3e0
@@ -84,4 +84,4 @@
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3507
+* GoCN归档：https://gocn.vip/topics/3507

--- a/201906/20190624-20190630.md
+++ b/201906/20190624-20190630.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3508
+* GoCN归档: https://gocn.vip/topics/3508
 
 ## GoCN每日新闻(2019-06-25)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.io/question/3531
+* GoCN归档: https://gocn.vip/topics/3531
 
 ## GoCN每日新闻(2019-06-26)
 
@@ -32,7 +32,7 @@
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3534
+* GoCN归档：https://gocn.vip/topics/3534
 
 
 ## GoCN每日新闻(2019-06-27)
@@ -45,7 +45,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3536
+* GoCN归档：https://gocn.vip/topics/3536
 
 ## GoCN每日新闻(2019-06-28)
 
@@ -57,7 +57,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3537
+* GoCN归档：https://gocn.vip/topics/3537
 
 ## GoCN每日新闻(2019-06-29)
 
@@ -69,7 +69,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3538
+* GoCN归档：https://gocn.vip/topics/3538
 
 ## GoCN每日新闻(2019-06-30)
 
@@ -81,4 +81,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3539
+* GoCN归档：https://gocn.vip/topics/3539

--- a/201907/20190701-20190707.md
+++ b/201907/20190701-20190707.md
@@ -8,7 +8,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3540
+- GoCN归档：https://gocn.vip/topics/3540
 
 ## GoCN每日新闻(2019-07-02)
 
@@ -20,7 +20,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3541
+- GoCN归档：https://gocn.vip/topics/3541
 
 ## GoCN每日新闻(2019-07-03)
 
@@ -32,7 +32,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3544
+- GoCN归档: https://gocn.vip/topics/3544
 
 ## GoCN每日新闻(2019-07-04)
 
@@ -44,7 +44,7 @@
 
 - 编辑: 何小云
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3548
+- GoCN归档: https://gocn.vip/topics/3548
 
 ## GoCN每日新闻(2019-07-05)
 
@@ -56,7 +56,7 @@
  
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3549
+- GoCN归档: https://gocn.vip/topics/3549
 
 ## GoCN每日新闻(2019-07-06)
 
@@ -68,7 +68,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3551
+- GoCN归档：https://gocn.vip/topics/3551
 
 ## GoCN每日新闻(2019-07-07)
 1. 打造最快的go模板引擎gorazor2.0 https://zhuanlan.zhihu.com/p/72522371
@@ -80,4 +80,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3552
+- GoCN归档：https://gocn.vip/topics/3552

--- a/201907/20190708-20190714.md
+++ b/201907/20190708-20190714.md
@@ -8,7 +8,7 @@
 
 - 编辑: 李俱顺Kevin
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3553
+- GoCN归档: https://gocn.vip/topics/3553
 
 ## GoCN每日新闻(2019-07-09)
 
@@ -20,7 +20,7 @@
 
 - 编辑: 傅小黑
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3556
+- GoCN归档: https://gocn.vip/topics/3556
 
 
 ## GoCN每日新闻(2019-07-10)
@@ -33,7 +33,7 @@
 
 - 编辑: yulibaozi
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3560
+- GoCN归档: https://gocn.vip/topics/3560
 
 
 ## GoCN每日新闻(2019-07-11)
@@ -46,7 +46,7 @@
 
 - 编辑: 李森森
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3578
+- GoCN归档：https://gocn.vip/topics/3578
 
 ## GoCN每日新闻(2019-07-12)
 
@@ -58,7 +58,7 @@
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3590
+* GoCN归档：https://gocn.vip/topics/3590
 
 ## GoCN每日新闻(2019-07-13)
 
@@ -70,7 +70,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3599
+* GoCN归档: https://gocn.vip/topics/3599
 
 ## GoCN每日新闻(2019-07-14)
 
@@ -82,4 +82,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3602
+* GoCN归档: https://gocn.vip/topics/3602

--- a/201907/20190715-20190721.md
+++ b/201907/20190715-20190721.md
@@ -8,7 +8,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3607
+- GoCN归档: https://gocn.vip/topics/3607
 
 ## GoCN每日新闻(2019-07-16)
 
@@ -19,11 +19,11 @@
 5. MongoDB 4.2 特性预览：https://www.mongodb.com/blog/post/mongodb-42-previewed-at-mongodb-world 
 
 招聘信息:
-* [北京-微博招聘]招聘golang工程师-广告平台: https://gocn.vip/question/3608
+* [北京-微博招聘]招聘golang工程师-广告平台: https://gocn.vip/topics/3608
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3612
+- GoCN归档: https://gocn.vip/topics/3612
 
 ## GoCN每日新闻(2019-07-17)
 
@@ -35,7 +35,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3614
+- GoCN归档: https://gocn.vip/topics/3614
 
 ## GoCN每日新闻(2019-07-18)
 
@@ -47,7 +47,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3616
+- GoCN归档: https://gocn.vip/topics/3616
 
 
 ## GoCN每日新闻(2019-07-19)
@@ -60,7 +60,7 @@
 
 - 编辑: 何小云
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3619
+- GoCN归档: https://gocn.vip/topics/3619
 
 
 ## GoCN每日新闻(2019-07-20)
@@ -73,7 +73,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档： https://gocn.vip/question/3620
+- GoCN归档： https://gocn.vip/topics/3620
 
 ## GoCN每日新闻(2019-07-21)
 1. Go语言调度(一):系统调度 https://www.jianshu.com/p/db0aea4d60ed
@@ -84,4 +84,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3621
+- GoCN归档：https://gocn.vip/topics/3621

--- a/201907/20190722-20190728.md
+++ b/201907/20190722-20190728.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3624
+* GoCN归档: https://gocn.vip/topics/3624
 
 
 
@@ -21,7 +21,7 @@
 5. Go 的 QML 绑定库 https://github.com/RadhiFadlillah/qamel
 * 编辑: 傅小黑 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3625
+* GoCN归档：https://gocn.vip/topics/3625
 
 ## GoCN每日新闻(2019-07-24)
 
@@ -33,7 +33,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3628
+* GoCN归档：https://gocn.vip/topics/3628
 
 
 ## GoCN每日新闻(2019-07-25)
@@ -46,7 +46,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3630
+* GoCN归档：https://gocn.vip/topics/3630
 
 ## GoCN每日新闻(2019-07-26)
 
@@ -60,7 +60,7 @@
 
 * 编辑: Razil
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/https://gocn.vip/question/3631
+* GoCN归档：https://gocn.vip/topics/3631
 
 ## GoCN每日新闻(2019-07-27)
 
@@ -72,7 +72,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3632
+* GoCN归档: https://gocn.vip/topics/3632
 
 ## GoCN每日新闻(2019-07-28)
 
@@ -86,4 +86,4 @@
 
 * 编辑: Razil  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/3633
+* GoCN归档：https://gocn.vip/topics/3633

--- a/201907/20190729-20190804.md
+++ b/201907/20190729-20190804.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋  
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/3634
+- GoCN归档：https://gocn.vip/topics/3634
 
 ## GoCN每日新闻(2019-07-30)
 
@@ -24,7 +24,7 @@
 
 - 编辑: 薛锦  
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/3637
+- GoCN归档：https://gocn.vip/topics/3637
 
 ## GoCN每日新闻(2019-07-31)
 
@@ -38,7 +38,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3640
+- GoCN归档: https://gocn.vip/topics/3640
 
 ## GoCN每日新闻(2019-08-01)
 
@@ -50,7 +50,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3644
+- GoCN归档: https://gocn.vip/topics/3644
 
 
 ## GoCN每日新闻(2019-08-02)
@@ -63,7 +63,7 @@
 
 - 编辑: 何小云
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3645
+- GoCN归档: https://gocn.vip/topics/3645
 
 
 ## GoCN每日新闻(2019-08-03)
@@ -76,7 +76,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/3646
+- GoCN归档: https://gocn.vip/topics/3646
 
 ## GoCN每日新闻(2019-08-04)
 
@@ -88,4 +88,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3647
+- GoCN归档：https://gocn.vip/topics/3647

--- a/201908/20190805-20190811.md
+++ b/201908/20190805-20190811.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3649
+* GoCN归档：https://gocn.vip/topics/3649
 
 ## GoCN每日新闻(2019-08-06)
 
@@ -22,7 +22,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3651
+* GoCN归档: https://gocn.vip/topics/3651
 
 
 ## GoCN每日新闻(2019-08-07)
@@ -37,7 +37,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3652
+* GoCN归档: https://gocn.vip/topics/3652
 
 
 ## GoCN每日新闻(2019-08-08)
@@ -52,7 +52,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3654
+* GoCN归档：https://gocn.vip/topics/3654
 
 ## GoCN每日新闻(2019-08-09)
 
@@ -66,7 +66,7 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3656
+* GoCN归档：https://gocn.vip/topics/3656
 
 ## GoCN每日新闻(2019-08-10)
 
@@ -80,7 +80,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3658
+* GoCN归档: https://gocn.vip/topics/3658
 
 ### GoCN每日新闻(2019-08-11)
 
@@ -94,4 +94,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3659
+* GoCN归档: https://gocn.vip/topics/3659

--- a/201908/20190812-20190818.md
+++ b/201908/20190812-20190818.md
@@ -10,7 +10,7 @@
 
 * 编辑: 宋佳洋 
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/3661
+* GoCN归档：https://gocn.vip/topics/3661
 
 ## GoCN每日新闻(2019-08-13)
 
@@ -24,7 +24,7 @@
 
 * 编辑: 薛锦 
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/3664
+* GoCN归档：https://gocn.vip/topics/3664
 
 ## GoCN每日新闻(2019-08-14)
 
@@ -36,7 +36,7 @@
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3665
+* GoCN归档：https://gocn.vip/topics/3665
 
 ## GoCN每日新闻(2019-08-15)
 
@@ -48,7 +48,7 @@
 
 * 编辑: 崔广章
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3666
+* GoCN归档：https://gocn.vip/topics/3666
 
 ## GoCN每日新闻(2019-08-16)
 
@@ -60,7 +60,7 @@
 
 * 编辑: 何小云
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3670
+* GoCN归档：https://gocn.vip/topics/3670
 
 ## GoCN每日新闻(2019-08-17)
 
@@ -72,7 +72,7 @@
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档： https://gocn.vip/question/3671
+* GoCN归档： https://gocn.vip/topics/3671
 
 ## GoCN每日新闻(2019-08-18)
 1. Golang译文之竞态检测器race https://juejin.im/post/5d5851aee51d4561c6784079
@@ -83,4 +83,4 @@
     
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3672
+* GoCN归档：https://gocn.vip/topics/3672

--- a/201908/20190819-20190825.md
+++ b/201908/20190819-20190825.md
@@ -8,7 +8,7 @@
     
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3673
+* GoCN归档：https://gocn.vip/topics/3673
 
 ## GoCN每日新闻(2019-08-20)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3674
+* GoCN归档: https://gocn.vip/topics/3674
 
 ## GoCN每日新闻(2019-08-21)
 
@@ -32,7 +32,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3675
+* GoCN归档: https://gocn.vip/topics/3675
 
 ## GoCN每日新闻(2019-08-22)
 
@@ -44,7 +44,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3676
+* GoCN归档: https://gocn.vip/topics/3676
 
 ## GoCN每日新闻(2019-08-23)
 
@@ -56,7 +56,7 @@
 
 * 编辑: Razil  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/3678
+* GoCN归档：https://gocn.vip/topics/3678
 
 ## GoCN每日新闻(2019-08-24)
 
@@ -68,7 +68,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3679
+* GoCN归档：https://gocn.vip/topics/3679
 
 ## GoCN每日新闻(2019-08-25)
 
@@ -80,4 +80,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3680
+* GoCN归档：https://gocn.vip/topics/3680

--- a/201908/20190826-20190901.md
+++ b/201908/20190826-20190901.md
@@ -8,7 +8,7 @@
 
 * 编辑: 宋佳洋 
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/3681
+* GoCN归档：https://gocn.vip/topics/3681
 
 ## GoCN每日新闻(2019-08-27)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 薛锦 
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/3684
+* GoCN归档：https://gocn.vip/topics/3684
 
 ## GoCN每日新闻(2019-08-28)
 
@@ -34,7 +34,7 @@
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/3686
+* GoCN归档：https://gocn.vip/topics/3686
 
 ## GoCN每日新闻(2019-08-29)
 
@@ -48,7 +48,7 @@
 
 * 编辑: 崔广章
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/3687
+* GoCN归档：https://gocn.vip/topics/3687
 
 ## GoCN每日新闻(2019-08-30)
 
@@ -62,7 +62,7 @@
 
 * 编辑: 何小云
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/3690
+* GoCN归档：https://gocn.vip/topics/3690
 
 
 ## GoCN每日新闻（2019-08-31）
@@ -76,7 +76,7 @@
 
 * 编辑: samurai 
 * 订阅新闻: http://tinyletter.com/gocn 
-* GoCN归档： https://gocn.vip/question/3691
+* GoCN归档： https://gocn.vip/topics/3691
 
 ## GoCN每日新闻(2019-09-01)
 1. Go结构体中属性顺序影响结构体的大小 https://www.pengrl.com/p/16608
@@ -87,4 +87,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3692
+- GoCN归档：https://gocn.vip/topics/3692

--- a/201909/20190902-20190907.md
+++ b/201909/20190902-20190907.md
@@ -10,7 +10,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3693
+* GoCN归档: https://gocn.vip/topics/3693
 
 
 ## GoCN每日新闻(2019-09-03)
@@ -25,7 +25,7 @@
 
 编辑: 傅小黑
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/3696
+GoCN归档: https://gocn.vip/topics/3696
 
 ## GoCN每日新闻(2019-09-04)
 
@@ -39,7 +39,7 @@ GoCN归档: https://gocn.vip/question/3696
 
 编辑: yulibaozi
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/3698
+GoCN归档: https://gocn.vip/topics/3698
 
 ## GoCN每日新闻(2019-09-05)
 
@@ -53,7 +53,7 @@ GoCN归档: https://gocn.vip/question/3698
 
 编辑: 李俱顺Kevin     
 订阅新闻: http://tinyletter.com/gocn    
-GoCN归档: https://gocn.vip/question/3701    
+GoCN归档: https://gocn.vip/topics/3701    
 
 ## GoCN每日新闻(2019-09-06)
 
@@ -68,7 +68,7 @@ GoCN归档: https://gocn.vip/question/3701
 
 * 编辑: Razil  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/3703
+* GoCN归档：https://gocn.vip/topics/3703
 
 ## GoCN每日新闻(2019-09-07)
 
@@ -82,7 +82,7 @@ GoCN归档: https://gocn.vip/question/3701
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3704
+* GoCN归档: https://gocn.vip/topics/3704
 
 ## GoCN每日新闻(2019-09-08)
 
@@ -96,4 +96,4 @@ GoCN归档: https://gocn.vip/question/3701
 
 * 编辑: lwhile 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/3706
+* GoCN归档: https://gocn.vip/topics/3706

--- a/201909/20190909-20190915.md
+++ b/201909/20190909-20190915.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋 
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/3707
+- GoCN归档：https://gocn.vip/topics/3707
 
 ## GoCN每日新闻(2019-09-10)
 
@@ -24,7 +24,7 @@
 
 - 编辑: 薛锦 
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/3710
+- GoCN归档：https://gocn.vip/topics/3710
 
 ## GoCN每日新闻(2019-09-11)
 
@@ -38,7 +38,7 @@
 
 - 编辑: 周云轩 
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/3767
+- GoCN归档：https://gocn.vip/topics/3767
 
 ## GoCN每日新闻(2019-09-12)
 
@@ -52,7 +52,7 @@
 
 - 编辑: 崔广章 
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/3791
+- GoCN归档：https://gocn.vip/topics/3791
 
 ## GoCN每日新闻(2019-09-13)
 
@@ -66,7 +66,7 @@
 
 - 编辑: 何小云 
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/3792
+- GoCN归档：https://gocn.vip/topics/3792
 
 ## GoCN每日新闻(2019-09-14)
 
@@ -80,7 +80,7 @@
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/3793
+* GoCN归档：https://gocn.vip/topics/3793
 
 ## GoCN每日新闻(2019-09-15)
 1. Go语言测试进阶版建议与技巧 https://pengrl.com/p/32101/
@@ -91,4 +91,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/3794
+- GoCN归档：https://gocn.vip/topics/3794

--- a/201909/20190916-20190922.md
+++ b/201909/20190916-20190922.md
@@ -10,7 +10,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/5760
+* GoCN归档：https://gocn.vip/topics/5760
 
 ## GoCN每日新闻(2019-09-17)
 
@@ -24,7 +24,7 @@
 
 编辑: 傅小黑
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/5762
+GoCN归档: https://gocn.vip/topics/5762
 
 ## GoCN每日新闻(2019-09-18)
 
@@ -38,7 +38,7 @@ GoCN归档: https://gocn.vip/question/5762
 
 编辑: yulibaozi
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/5764
+GoCN归档: https://gocn.vip/topics/5764
 
 
 ## GoCN每日新闻(2019-09-19)
@@ -51,7 +51,7 @@ GoCN归档: https://gocn.vip/question/5764
 
 编辑: 李森森
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/5766
+GoCN归档: https://gocn.vip/topics/5766
 
 ## GoCN每日新闻(2019-09-20)
 
@@ -65,7 +65,7 @@ GoCN归档: https://gocn.vip/question/5766
 
 * 编辑: Razil  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/5767  
+* GoCN归档：https://gocn.vip/topics/5767  
 
 ## GoCN每日新闻(2019-09-21)
 
@@ -80,7 +80,7 @@ GoCN归档: https://gocn.vip/question/5766
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/5772
+* GoCN归档: https://gocn.vip/topics/5772
 
 ## GoCN每日新闻(2019-09-22)
 
@@ -94,4 +94,4 @@ GoCN归档: https://gocn.vip/question/5766
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/5795
+* GoCN归档: https://gocn.vip/topics/5795

--- a/201909/20190923-20190929.md
+++ b/201909/20190923-20190929.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/5875
+- GoCN归档: https://gocn.vip/topics/5875
 
 ## GoCN每日新闻(2019-09-24)
 
@@ -24,7 +24,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/5891
+- GoCN归档: https://gocn.vip/topics/5891
 
 ## GoCN每日新闻(2019-09-25)
 
@@ -38,7 +38,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6042
+- GoCN归档: https://gocn.vip/topics/6042
 
 ## GoCN每日新闻(2019-09-26)
 
@@ -52,7 +52,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6044
+- GoCN归档: https://gocn.vip/topics/6044
 
 ## GoCN每日新闻(2019-09-27)
 
@@ -66,7 +66,7 @@
 
 - 编辑: 何小云
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6045
+- GoCN归档: https://gocn.vip/topics/6045
 
 ## GoCN每日新闻(2019-09-28)
 
@@ -80,7 +80,7 @@
 
 - 编辑: samurai 
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/6048
+- GoCN归档：https://gocn.vip/topics/6048
 
 
 ## GoCN每日新闻(2019-09-29)
@@ -95,4 +95,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/6049
+- GoCN归档：https://gocn.vip/topics/6049

--- a/201909/20190930-20191006.md
+++ b/201909/20190930-20191006.md
@@ -7,7 +7,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/6053
+* GoCN归档：https://gocn.vip/topics/6053
 
 ## GoCN每日新闻(2019-10-01)
 
@@ -19,7 +19,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6055
+* GoCN归档: https://gocn.vip/topics/6055
 
 ## GoCN每日新闻(2019-10-02)
 
@@ -31,7 +31,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6056
+* GoCN归档: https://gocn.vip/topics/6056
 
 
 ## GoCN每日新闻(2019-10-03)
@@ -44,7 +44,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6057
+* GoCN归档: https://gocn.vip/topics/6057
 
 ## GoCN每日新闻(2019-10-04)
 
@@ -56,7 +56,7 @@
 
 * 编辑: Razil  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/6058  
+* GoCN归档：https://gocn.vip/topics/6058  
 
 ## GoCN每日新闻(2019-10-05)
 
@@ -68,7 +68,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6059
+* GoCN归档: https://gocn.vip/topics/6059
 
 ## GoCN每日新闻(2019-10-06)
 
@@ -80,4 +80,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6060
+* GoCN归档: https://gocn.vip/topics/6060

--- a/201910/20191007-20191013.md
+++ b/201910/20191007-20191013.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6242
+- GoCN归档: https://gocn.vip/topics/6242
 
 ## GoCN每日新闻(2019-10-08)
 
@@ -22,7 +22,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6393
+- GoCN归档: https://gocn.vip/topics/6393
 
 
 ## GoCN每日新闻(2019-10-09)
@@ -35,7 +35,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6411
+- GoCN归档: https://gocn.vip/topics/6411
 
 ## GoCN每日新闻(2019-10-10)
 
@@ -47,7 +47,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6414
+- GoCN归档: https://gocn.vip/topics/6414
 
 ## GoCN每日新闻(2019-10-11)
 
@@ -59,7 +59,7 @@
 
 - 编辑: 何小云
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6416
+- GoCN归档: https://gocn.vip/topics/6416
 
 ## GoCN每日新闻(2019-10-12)
 
@@ -71,7 +71,7 @@
 
 - 编辑: samurai 
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/6417
+- GoCN归档：https://gocn.vip/topics/6417
 
 ## GoCN每日新闻(2019-10-13)
 1. 通过测试学习Go语言 https://mp.weixin.qq.com/s/MGT_yoP_NdWVGpwlAJFK4A
@@ -82,4 +82,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6426
+- GoCN归档：https://gocn.vip/topics/6426

--- a/201910/20191014-20191020.md
+++ b/201910/20191014-20191020.md
@@ -10,7 +10,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/4627
+* GoCN归档：https://gocn.vip/topics/4627
 
 ## GoCN每日新闻(2019-10-15)
 
@@ -22,7 +22,7 @@
 
 编辑: 傅小黑
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/6429
+GoCN归档: https://gocn.vip/topics/6429
 
 ## GoCN每日新闻(2019-10-16)
 
@@ -34,7 +34,7 @@ GoCN归档: https://gocn.vip/question/6429
 
 编辑: yulibaozi
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/6432
+GoCN归档: https://gocn.vip/topics/6432
 
 
 ## GoCN每日新闻(2019-10-17)
@@ -47,7 +47,7 @@ GoCN归档: https://gocn.vip/question/6432
 
 编辑: 李森森
 订阅新闻: http://tinyletter.com/gocn
-GoCN归档: https://gocn.vip/question/6436
+GoCN归档: https://gocn.vip/topics/6436
 
 ## GoCN每日新闻(2019-10-18)
 
@@ -59,7 +59,7 @@ GoCN归档: https://gocn.vip/question/6436
 
 * 编辑: Razil  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/6438  
+* GoCN归档：https://gocn.vip/topics/6438  
 
 ## GoCN每日新闻(2019-10-19)
 
@@ -71,7 +71,7 @@ GoCN归档: https://gocn.vip/question/6436
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6441
+* GoCN归档: https://gocn.vip/topics/6441
 
 ## GoCN每日新闻(2019-10-20)
 
@@ -85,4 +85,4 @@ GoCN归档: https://gocn.vip/question/6436
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6442
+* GoCN归档: https://gocn.vip/topics/6442

--- a/201910/20191021-20191027.md
+++ b/201910/20191021-20191027.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6443
+- GoCN归档: https://gocn.vip/topics/6443
 
 ## GoCN每日新闻(2019-10-22)
 
@@ -24,7 +24,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6444
+- GoCN归档: https://gocn.vip/topics/6444
 
 ## GoCN每日新闻(2019-10-23)
 
@@ -38,7 +38,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6446
+- GoCN归档: https://gocn.vip/topics/6446
 
 
 ## GoCN每日新闻(2019-10-24)
@@ -53,7 +53,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6448
+- GoCN归档: https://gocn.vip/topics/6448
 
 ## GoCN每日新闻(2019-10-25)
 
@@ -67,7 +67,7 @@
 
 - 编辑: 何小云
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6449
+- GoCN归档: https://gocn.vip/topics/6449
 
 ## GoCN每日新闻(2019-10-26)
 
@@ -81,7 +81,7 @@
 
 - 编辑: samurai 
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/6450
+- GoCN归档：https://gocn.vip/topics/6450
 
 
 ## GoCN每日新闻(2019-10-27)
@@ -93,4 +93,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6451
+- GoCN归档：https://gocn.vip/topics/6451

--- a/201910/20191028-20191103.md
+++ b/201910/20191028-20191103.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/6452
+* GoCN归档：https://gocn.vip/topics/6452
 
 ## GoCN每日新闻(2019-10-29)
 
@@ -20,7 +20,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6453
+* GoCN归档: https://gocn.vip/topics/6453
 
 ## GoCN每日新闻(2019-10-30)
 
@@ -32,7 +32,7 @@
 
 * 编辑: yulibaozi 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6455
+* GoCN归档: https://gocn.vip/topics/6455
 
 ## GoCN每日新闻(2019-10-31)
 
@@ -44,7 +44,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6456
+* GoCN归档: https://gocn.vip/topics/6456
 
 ## GoCN每日新闻(2019-11-01)
 
@@ -56,7 +56,7 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN 归档: https://gocn.vip/question/6458
+* GoCN 归档: https://gocn.vip/topics/6458
 
 ## GoCN每日新闻(2019-11-02)
 
@@ -68,7 +68,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6459
+* GoCN归档: https://gocn.vip/topics/6459
 
 ## GoCN每日新闻(2019-11-03)
 
@@ -80,4 +80,4 @@
 
 * 编辑: Razil  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/6460  
+* GoCN归档：https://gocn.vip/topics/6460  

--- a/201911/20191104-20191110.md
+++ b/201911/20191104-20191110.md
@@ -8,7 +8,7 @@
 
 编辑: 宋佳洋  
 订阅新闻: http://tinyletter.com/gocn  
-GoCN归档：https://gocn.vip/question/6461
+GoCN归档：https://gocn.vip/topics/6461
 
 ## GoCN每日新闻(2019-11-05)
 
@@ -20,7 +20,7 @@ GoCN归档：https://gocn.vip/question/6461
 
 - 编辑: 薛锦 
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/6463
+- GoCN归档：https://gocn.vip/topics/6463
 
 ## GoCN每日新闻(2019-11-06)
 
@@ -35,7 +35,7 @@ GoCN归档：https://gocn.vip/question/6461
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/6595
+- GoCN归档：https://gocn.vip/topics/6595
 
 
 ## GoCN每日新闻(2019-11-07)
@@ -51,7 +51,7 @@ GoCN归档：https://gocn.vip/question/6461
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn 
-- GoCN归档：https://gocn.vip/question/6597
+- GoCN归档：https://gocn.vip/topics/6597
 
 ## GoCN每日新闻(2019-11-08)
 
@@ -66,7 +66,7 @@ GoCN归档：https://gocn.vip/question/6461
 
 - 编辑: 何小云
 - 订阅新闻: http://tinyletter.com/gocn 
-- GoCN归档: https://gocn.vip/question/6600
+- GoCN归档: https://gocn.vip/topics/6600
 
 ## GoCN每日新闻(2019-11-10)
 1. Go Netpoll I/O多路复用构建原生网络模型之源码深度解析 https://taohuawu.club/go-netpoll-io-multiplexing-reactor
@@ -77,4 +77,4 @@ GoCN归档：https://gocn.vip/question/6461
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6602
+- GoCN归档：https://gocn.vip/topics/6602

--- a/201911/20191111-20191117.md
+++ b/201911/20191111-20191117.md
@@ -11,7 +11,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/6603
+* GoCN归档：https://gocn.vip/topics/6603
 
 ## GoCN每日新闻(2019-11-12)
 
@@ -23,7 +23,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6605
+* GoCN归档: https://gocn.vip/topics/6605
 
 
 ## GoCN每日新闻(2019-11-13)
@@ -36,7 +36,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6606
+* GoCN归档: https://gocn.vip/topics/6606
 
 
 ## GoCN每日新闻(2019-11-14)
@@ -52,7 +52,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6607
+* GoCN归档: https://gocn.vip/topics/6607
 
 
 ## GoCN每日新闻(2019-11-15)
@@ -68,7 +68,7 @@
 
 * 编辑: Razil  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/6612  
+* GoCN归档：https://gocn.vip/topics/6612  
 
 ## GoCN每日新闻(2019-11-16)
 
@@ -80,7 +80,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6613
+* GoCN归档: https://gocn.vip/topics/6613
 
 ## GoCN每日新闻(2019-11-17)
 
@@ -92,4 +92,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6614
+* GoCN归档: https://gocn.vip/topics/6614

--- a/201911/20191118-20191124.md
+++ b/201911/20191118-20191124.md
@@ -8,7 +8,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6615
+- GoCN归档: https://gocn.vip/topics/6615
 
 ## GoCN每日新闻(2019-11-19)
 
@@ -20,7 +20,7 @@
 
 - 编辑: 薛锦 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6616
+- GoCN归档: https://gocn.vip/topics/6616
 
 ## GoCN每日新闻(2019-11-20)
 
@@ -32,7 +32,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6618
+- GoCN归档: https://gocn.vip/topics/6618
 
 
 ## GoCN每日新闻(2019-11-21)
@@ -45,7 +45,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6620
+- GoCN归档: https://gocn.vip/topics/6620
 
 
 ## GoCN每日新闻(2019-11-22)
@@ -70,7 +70,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6623
+- GoCN归档: https://gocn.vip/topics/6623
 
 
 ## GoCN每日新闻(2019-11-24)
@@ -82,4 +82,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6624
+- GoCN归档：https://gocn.vip/topics/6624

--- a/201911/20191125-20191201.md
+++ b/201911/20191125-20191201.md
@@ -10,7 +10,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/6626
+* GoCN归档：https://gocn.vip/topics/6626
 
 ## GoCN每日新闻(2019-11-26)
 
@@ -25,7 +25,7 @@
 
 * 编辑: 傅小黑
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6627
+* GoCN归档: https://gocn.vip/topics/6627
 
 
 ## GoCN每日新闻(2019-11-27)
@@ -41,7 +41,7 @@
 
 * 编辑: yulibaozi
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6630
+* GoCN归档: https://gocn.vip/topics/6630
 
 ## GoCN每日新闻(2019-11-28)
 
@@ -56,7 +56,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6631
+* GoCN归档: https://gocn.vip/topics/6631
 
 
 ## GoCN每日新闻(2019-11-29)
@@ -72,7 +72,7 @@
 
 * 编辑: Razil  
 * 订阅新闻: http://tinyletter.com/gocn  
-* GoCN归档：https://gocn.vip/question/6633  
+* GoCN归档：https://gocn.vip/topics/6633  
 
 ## GoCN每日新闻(2019-11-30)
 
@@ -86,7 +86,7 @@
 
 * 编辑: 马怀博 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6635
+* GoCN归档: https://gocn.vip/topics/6635
 
 ## GoCN每日新闻(2019-12-01)
 
@@ -100,4 +100,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6636
+* GoCN归档: https://gocn.vip/topics/6636

--- a/201912/20191202-20191208.md
+++ b/201912/20191202-20191208.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6637
+- GoCN归档: https://gocn.vip/topics/6637
 
 ## GoCN每日新闻(2019-12-03)
 
@@ -24,7 +24,7 @@
 
 - 编辑: 薛锦 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6639
+- GoCN归档: https://gocn.vip/topics/6639
 
 ## GoCN每日新闻(2019-12-04)
 
@@ -38,7 +38,7 @@
 
 - 编辑: 周云轩 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6640
+- GoCN归档: https://gocn.vip/topics/6640
 
 ## GoCN每日新闻(2019-12-05)
 
@@ -52,7 +52,7 @@
 
 - 编辑: 崔广章 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6642
+- GoCN归档: https://gocn.vip/topics/6642
 
 ## GoCN每日新闻(2019-12-06)
 
@@ -66,7 +66,7 @@
 
 - 编辑: 何小云 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6643
+- GoCN归档: https://gocn.vip/topics/6643
 
 ## GoCN每日新闻(2019-12-07)
 
@@ -81,7 +81,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6644
+- GoCN归档：https://gocn.vip/topics/6644
 
 
 ## GoCN每日新闻(2019-12-08)
@@ -93,4 +93,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6645
+- GoCN归档：https://gocn.vip/topics/6645

--- a/201912/20191209-20191215.md
+++ b/201912/20191209-20191215.md
@@ -11,7 +11,7 @@
 
 - 编辑: 李俱顺Kevin
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6646
+- GoCN归档：https://gocn.vip/topics/6646
 
 
 
@@ -28,7 +28,7 @@
 
 - 编辑: 傅小黑
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6647
+- GoCN归档：https://gocn.vip/topics/6647
 
 ## GoCN每日新闻（2019-12-11）
 
@@ -44,7 +44,7 @@
 
 - 编辑: yulibaozi
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6649
+- GoCN归档：https://gocn.vip/topics/6649
 
 ## GoCN每日新闻(2019-12-12)
 
@@ -59,7 +59,7 @@
 
 - 编辑: 李森森
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6650
+- GoCN归档: https://gocn.vip/topics/6650
 
 ## GoCN每日新闻(2019-12-13)
 
@@ -74,7 +74,7 @@
 
 - 编辑: Razil  
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/6651      
+- GoCN归档：https://gocn.vip/topics/6651      
 
 ## GoCN每日新闻(2019-12-14)
 
@@ -88,7 +88,7 @@
 
 - 编辑: 马怀博 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6652
+- GoCN归档: https://gocn.vip/topics/6652
 
 ## GoCN每日新闻(2019-12-15)
 
@@ -102,4 +102,4 @@
 
 - 编辑: lwh
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6653
+- GoCN归档：https://gocn.vip/topics/6653

--- a/201912/20191216-20191222.md
+++ b/201912/20191216-20191222.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6654
+- GoCN归档：https://gocn.vip/topics/6654
 
 ## GoCN每日新闻(2019-12-17)
 
@@ -24,7 +24,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6655
+- GoCN归档：https://gocn.vip/topics/6655
 
 ## GoCN每日新闻(2019-12-18)
 
@@ -38,7 +38,7 @@
 
 - 编辑: 周云轩
  订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6662
+- GoCN归档：https://gocn.vip/topics/6662
 
 ## GoCN每日新闻(2019-12-19)
 
@@ -52,7 +52,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6665
+- GoCN归档：https://gocn.vip/topics/6665
 
 ## GoCN每日新闻(2019-12-20)
 
@@ -66,7 +66,7 @@
 
 - 编辑: 何小云
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6666
+- GoCN归档: https://gocn.vip/topics/6666
 
 ## GoCN每日新闻(2019-12-21)
 
@@ -80,7 +80,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn 
-- GoCN归档: https://gocn.vip/question/6667
+- GoCN归档: https://gocn.vip/topics/6667
 
 ## GoCN每日新闻(2019-12-22)
 祝大家冬至快乐！！
@@ -95,4 +95,4 @@
 
 - 编辑: Razil  
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/6668      
+- GoCN归档：https://gocn.vip/topics/6668      

--- a/201912/20191223-20191229.md
+++ b/201912/20191223-20191229.md
@@ -8,7 +8,7 @@
 
 - 编辑: 李俱顺Kevin
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6669
+- GoCN归档：https://gocn.vip/topics/6669
 
 ## GoCN 每日新闻（2019-12-24）
 
@@ -22,7 +22,7 @@
 
 - 编辑: 傅小黑
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6670
+- GoCN归档：https://gocn.vip/topics/6670
 
 
 ## GoCN 每日新闻（2019-12-25）
@@ -37,7 +37,7 @@
 
 - 编辑: yulibaozi
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6671
+- GoCN归档：https://gocn.vip/topics/6671
 
 ## GoCN每日新闻(2019-12-26)
 
@@ -49,7 +49,7 @@
 
 - 编辑: 李森森
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6672
+- GoCN归档: https://gocn.vip/topics/6672
 
 ## GoCN每日新闻(2019-12-27)
 
@@ -63,7 +63,7 @@
 
 - 编辑: Razil  
 - 订阅新闻: http://tinyletter.com/gocn  
-- GoCN归档：https://gocn.vip/question/6673      
+- GoCN归档：https://gocn.vip/topics/6673      
 
 ## GoCN每日新闻(2019-12-28)
 
@@ -77,7 +77,7 @@
 
 - 编辑: 马怀博 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6674
+- GoCN归档: https://gocn.vip/topics/6674
 
 GoCN每日新闻(2019-12-29)
 
@@ -91,4 +91,4 @@ GoCN每日新闻(2019-12-29)
 
 - 编辑: lwhile
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6675
+- GoCN归档：https://gocn.vip/topics/6675

--- a/201912/20191230-20200105.md
+++ b/201912/20191230-20200105.md
@@ -10,7 +10,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6676
+- GoCN归档：https://gocn.vip/topics/6676
 
 ## GoCN每日新闻(2019-12-31)
 
@@ -24,7 +24,7 @@
 
 - 编辑: 薛锦
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6677
+- GoCN归档：https://gocn.vip/topics/6677
 
 ## GoCN每日新闻(2020-01-01)
 祝大家2020元旦快乐！！
@@ -39,7 +39,7 @@
 
 - 编辑: 周云轩
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6678
+- GoCN归档：https://gocn.vip/topics/6678
 
 
 ## GoCN每日新闻(2020-01-02)
@@ -54,7 +54,7 @@
 
 - 编辑: 崔广章
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6679
+- GoCN归档：https://gocn.vip/topics/6679
 
 
 ## GoCN每日新闻(2020-01-03)
@@ -69,7 +69,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6680
+- GoCN归档：https://gocn.vip/topics/6680
 
 ## GoCN每日新闻(2020-01-04)
 
@@ -81,7 +81,7 @@
 
 - 编辑: 何小云
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6683
+- GoCN归档: https://gocn.vip/topics/6683
 
 ## GoCN每日新闻(2020-01-05)
 1. Go语言学习Sync.Pool https://juejin.im/post/5e103018e51d45416063f69b
@@ -92,4 +92,4 @@
 
 - 编辑: 罗发宣
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6685
+- GoCN归档：https://gocn.vip/topics/6685

--- a/202001/20200106-20200112.md
+++ b/202001/20200106-20200112.md
@@ -8,7 +8,7 @@
 
 - 编辑: 李俱顺Kevin
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6686
+- GoCN归档：https://gocn.vip/topics/6686
 
 
 ## GoCN 每日新闻（2020-01-07）
@@ -21,7 +21,7 @@
 
 - 编辑: 傅小黑
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6687
+- GoCN归档：https://gocn.vip/topics/6687
 
 ## GoCN 每日新闻（2020-01-08）
 
@@ -33,7 +33,7 @@
 
 - 编辑: yulibaozi
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6690
+- GoCN归档：https://gocn.vip/topics/6690
 
 ## GoCN每日新闻(2020-01-09)
 
@@ -45,7 +45,7 @@
 
 - 编辑: 李森森
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6691
+- GoCN归档: https://gocn.vip/topics/6691
 
 ## GoCN每日新闻(2020-01-10)
 
@@ -57,7 +57,7 @@
 
 - 编辑: Razil
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6692  
+- GoCN归档：https://gocn.vip/topics/6692  
 
 ## GoCN每日新闻(2020-01-11)
 
@@ -69,7 +69,7 @@
 
 - 编辑: 马怀博 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6693
+- GoCN归档: https://gocn.vip/topics/6693
 
 ## GoCN每日新闻(2020-01-12)
 
@@ -81,4 +81,4 @@
 
 - 编辑: lwhile
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6694
+- GoCN归档: https://gocn.vip/topics/6694

--- a/202001/20200113-20200119.md
+++ b/202001/20200113-20200119.md
@@ -10,7 +10,7 @@
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6696
+* GoCN归档: https://gocn.vip/topics/6696
 
 ## GoCN每日新闻(2020-01-14)
 
@@ -24,7 +24,7 @@
 
 * 编辑: 薛锦 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6697
+* GoCN归档: https://gocn.vip/topics/6697
 
 ## GoCN每日新闻(2020-01-15)
 
@@ -38,7 +38,7 @@
 
 * 编辑: 周云轩 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6698
+* GoCN归档: https://gocn.vip/topics/6698
 
 ## GoCN每日新闻(2020-01-16)
 
@@ -52,7 +52,7 @@
 
 * 编辑: 周云轩 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6699
+* GoCN归档: https://gocn.vip/topics/6699
 
 ## GoCN每日新闻(2020-01-17)
 
@@ -66,7 +66,7 @@
 
 * 编辑: 何小云 
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6700
+* GoCN归档: https://gocn.vip/topics/6700
 
 
 ## GoCN每日新闻(2020-01-18)
@@ -81,7 +81,7 @@
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6701
+* GoCN归档: https://gocn.vip/topics/6701
 
 ## GoCN每日新闻(2020-01-19)
 1. gout:Golang流式http client https://github.com/guonaihong/gout
@@ -92,4 +92,4 @@
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6703
+* GoCN归档: https://gocn.vip/topics/6703

--- a/202001/20200120-20200126.md
+++ b/202001/20200120-20200126.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/6704
+* GoCN归档：https://gocn.vip/topics/6704
 
 ## GoCN每日新闻(2020-01-21)
 
@@ -31,7 +31,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6708
+* GoCN归档: https://gocn.vip/topics/6708
 
 
 
@@ -46,7 +46,7 @@
 
 - 编辑: yulibaozi
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6709
+- GoCN归档：https://gocn.vip/topics/6709
 
 
 ## GoCN每日新闻(2020-01-24)
@@ -60,7 +60,7 @@
 
 - 编辑: Razil
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6710
+- GoCN归档：https://gocn.vip/topics/6710
 
 
 ## GoCN每日新闻(2020-01-25)
@@ -74,7 +74,7 @@
 
 - 编辑: 马怀博 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6711
+- GoCN归档: https://gocn.vip/topics/6711
 
 ## GoCN 每日新闻（2020-01-26）
 
@@ -86,4 +86,4 @@
 
 - 编辑: astaxie
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6712
+- GoCN归档: https://gocn.vip/topics/6712

--- a/202001/20200127-20200202.md
+++ b/202001/20200127-20200202.md
@@ -9,7 +9,7 @@
 
 * 编辑: 宋佳洋
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/6713
+* GoCN归档：https://gocn.vip/topics/6713
 
 ## GoCN 每日新闻（2020-01-28）
 
@@ -21,7 +21,7 @@
 
 * 编辑: 薛锦
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/6714
+* GoCN归档：https://gocn.vip/topics/6714
 
 ## GoCN 每日新闻（2020-01-29）
 
@@ -33,7 +33,7 @@
 
 * 编辑: 周云轩
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/6715
+* GoCN归档：https://gocn.vip/topics/6715
 
 ## GoCN 每日新闻（2020-01-30）
 
@@ -46,7 +46,7 @@
 
 * 编辑: 崔广章
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/6716
+* GoCN归档：https://gocn.vip/topics/6716
 
 ## GoCN每日新闻(2020-02-01)
 
@@ -58,7 +58,7 @@
 
 * 编辑: samurai
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6719
+* GoCN归档: https://gocn.vip/topics/6719
 
 ## GoCN每日新闻(2020-02-02)
 1. 调度系统设计精要 https://mp.weixin.qq.com/s/jI2ruzGLZRJmf9H49z3ojA
@@ -69,4 +69,4 @@
 
 * 编辑: 罗发宣
 * 订阅新闻: http://tinyletter.com/gocn
-& GoCN归档：https://gocn.vip/question/6720
+& GoCN归档：https://gocn.vip/topics/6720

--- a/202002/20200203-20200209.md
+++ b/202002/20200203-20200209.md
@@ -8,7 +8,7 @@
 
 * 编辑: 李俱顺Kevin
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档：https://gocn.vip/question/6721
+* GoCN归档：https://gocn.vip/topics/6721
 
 ## GoCN 每日新闻 (2020-02-04)
 
@@ -20,7 +20,7 @@
 
 - 编辑: 傅小黑
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6724
+- GoCN归档：https://gocn.vip/topics/6724
 
 ## GoCN 每日新闻 (2020-02-05)
 
@@ -32,7 +32,7 @@
 
 - 编辑: yulibaozi
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6726
+- GoCN归档：https://gocn.vip/topics/6726
 
 
 ## GoCN每日新闻(2020-02-06)
@@ -45,7 +45,7 @@
 
 * 编辑: 李森森
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6727
+* GoCN归档: https://gocn.vip/topics/6727
 
 
 ## GoCN每日新闻(2020-02-07)
@@ -58,7 +58,7 @@
 
 - 编辑: Razil
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/6728  
+- GoCN归档：https://gocn.vip/topics/6728  
 
 ## GoCN每日新闻(2020-02-08)
 
@@ -70,7 +70,7 @@
 
 - 编辑: 马怀博 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6729
+- GoCN归档: https://gocn.vip/topics/6729
 
 ## GoCN每日新闻(2020-02-09)
 
@@ -82,4 +82,4 @@
 
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
-* GoCN归档: https://gocn.vip/question/6730
+* GoCN归档: https://gocn.vip/topics/6730

--- a/202002/20200210-20200216.md
+++ b/202002/20200210-20200216.md
@@ -8,7 +8,7 @@
 
 - 编辑: 宋佳洋
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6732
+- GoCN归档: https://gocn.vip/topics/6732
 
 ## GoCN每日新闻(2020-02-11)
  
@@ -20,7 +20,7 @@
 
 - 编辑: 薛锦 
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档: https://gocn.vip/question/6733
+- GoCN归档: https://gocn.vip/topics/6733
 
 ## GoCN每日新闻(2020-02-12)
  

--- a/202003/20200316-20200322.md
+++ b/202003/20200316-20200322.md
@@ -107,4 +107,4 @@ GoCN归档：https://gocn.vip/topics/10053
 
 - 编辑: lwhile
 - 订阅新闻: http://tinyletter.com/gocn
-- GoCN归档：https://gocn.vip/question/10088
+- GoCN归档：https://gocn.vip/topics/10088

--- a/202003/20200323-20200329.md
+++ b/202003/20200323-20200329.md
@@ -80,7 +80,7 @@
 
 - 编辑: samurai
 - 订阅新闻: http://tinyletter.com/gocn 
-- GoCN归档: https://gocn.vip/question/10134
+- GoCN归档: https://gocn.vip/topics/10134
 
 ## GoCN每日新闻(2020-03-29)
 
@@ -92,4 +92,4 @@
 
 - 编辑: astaxie
 - 订阅新闻: http://tinyletter.com/gocn 
-- GoCN归档: https://gocn.vip/question/10137
+- GoCN归档: https://gocn.vip/topics/10137

--- a/202003/20200330-20200405.md
+++ b/202003/20200330-20200405.md
@@ -8,7 +8,7 @@
 
 - 编辑: 李俱顺Kevin
 - 订阅新闻: http://tinyletter.com/gocn 
-- GoCN归档: https://gocn.vip/question/10150
+- GoCN归档: https://gocn.vip/topics/10150
 
 ## GoCN 每日新闻（2020-03-31）
 

--- a/202004/20200413-20200419.md
+++ b/202004/20200413-20200419.md
@@ -91,4 +91,4 @@
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
 * 招聘专区: https://gocn.vip/jobs
-* GoCN归档：https://gocn.vip/question/10270
+* GoCN归档：https://gocn.vip/topics/10270

--- a/202007/20200720-20200726.md
+++ b/202007/20200720-20200726.md
@@ -77,7 +77,7 @@
 * 编辑: 马怀博
 * 订阅新闻: http://tinyletter.com/gocn
 * 招聘专区: https://gocn.vip/jobs
-* GoCN归档: https://gocn.vip/question/10736
+* GoCN归档: https://gocn.vip/topics/10736
 
 GoCN每日新闻(2020-07-26)
 
@@ -90,5 +90,5 @@ GoCN每日新闻(2020-07-26)
 * 编辑: lwhile
 * 订阅新闻: http://tinyletter.com/gocn
 * 招聘专区: https://gocn.vip/jobs
-* GoCN归档: https://gocn.vip/question/10737
+* GoCN归档: https://gocn.vip/topics/10737
 


### PR DESCRIPTION
gocn 的归档链接已全部替换修正，gocn 域名下的技术文章 99% 已修正

1、修复 gocn.vip/question 直接变更为 gocn.vip/topics
2、修复 gocn.io/question 直接变更为 gocn.vip/topics
3、根据标题进行文章追溯，修复 gocn.io/article 变更为正确的 gocn.vip/topics 链接

@TODO gocn.io 域名下的部分历史招聘信息链接没有修复【未修复链接皆为 17-18 年历史信息】
@TODO 201805/20180507-20180513.md:1. NSQ源码剖析 https://gocn.io/article/785 文章链接未成功追溯

Signed-off-by: limingshuang <lms.minsonlee@gmail.com>